### PR TITLE
feat: per-agent metadata DEK derivation in Vault

### DIFF
--- a/mcp/vault/vault_mcp.py
+++ b/mcp/vault/vault_mcp.py
@@ -1,6 +1,7 @@
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 import base64
+import functools
 import hashlib
 import heapq
 import hmac
@@ -137,6 +138,7 @@ cipher = Cipher(enc_key_path=enc_key_path, dim=DIM)
 # =============================================================================
 # Per-Agent Metadata Key Derivation
 # =============================================================================
+@functools.lru_cache(maxsize=1)
 def _load_master_key() -> bytes:
     """Load MetadataKey as master key for per-agent DEK derivation."""
     from pyenvector.utils.utils import get_key_stream
@@ -238,7 +240,7 @@ def _get_public_key_impl(token: str) -> str:
     bundle["key_id"] = KEY_ID
 
     # Per-agent metadata DEK: derived from master key + token-based agent_id
-    agent_id = hashlib.sha256(token.encode('utf-8')).hexdigest()[:16]
+    agent_id = hashlib.sha256(token.encode('utf-8')).hexdigest()[:32]
     master_key = _load_master_key()
     agent_dek = derive_agent_key(master_key, agent_id)
     bundle["agent_id"] = agent_id
@@ -252,7 +254,7 @@ mcp = FastMCP("enVector-Vault")
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, destructiveHint=False))
 def get_public_key(token: str) -> str:
     """
-    Returns the public key bundle (EncKey, EvalKey).
+    Returns the public key bundle and per-agent metadata DEK.
     This bundle allows the Agent to encrypt data/queries and register keys with the Cloud.
 
     Args:
@@ -262,7 +264,11 @@ def get_public_key(token: str) -> str:
         JSON string containing:
         {
             "EncKey.json": "...",
-            "EvalKey.json": "..."
+            "EvalKey.json": "...",
+            "index_name": "<team index>",
+            "key_id": "<vault key id>",
+            "agent_id": "<128-bit hex agent identifier>",
+            "agent_dek": "<base64 AES-256 DEK for metadata encryption>"
         }
     """
     start_time = time.time()
@@ -402,11 +408,15 @@ def _decrypt_metadata_impl(token: str, encrypted_metadata_list: list[str]) -> st
         master_key = _load_master_key()
         results = []
         for blob_str in encrypted_metadata_list:
-            blob = json.loads(blob_str)
-            agent_id = blob["a"]
-            ct_b64 = blob["c"]
-            agent_dek = derive_agent_key(master_key, agent_id)
-            decrypted = aes_decrypt_metadata(ct_b64, agent_dek)
+            try:
+                blob = json.loads(blob_str)
+                agent_id = blob["a"]
+                ct_b64 = blob["c"]
+                agent_dek = derive_agent_key(master_key, agent_id)
+                decrypted = aes_decrypt_metadata(ct_b64, agent_dek)
+            except (json.JSONDecodeError, KeyError):
+                # Legacy format: plain base64, decrypt with master metadata key
+                decrypted = aes_decrypt_metadata(blob_str, metadata_key_path)
             if isinstance(decrypted, bytes):
                 decrypted = decrypted.decode('utf-8')
             results.append(decrypted)

--- a/tests/unit/test_metadata_dek.py
+++ b/tests/unit/test_metadata_dek.py
@@ -1,0 +1,198 @@
+"""
+Unit tests for per-agent metadata DEK derivation and decrypt_metadata.
+
+Uses mock-based approach: aes_decrypt_metadata is mocked to test the
+envelope parsing, per-agent key derivation, and legacy fallback logic
+without requiring real FHE keys.
+"""
+import pytest
+import sys
+import os
+import json
+import base64
+from unittest.mock import MagicMock, patch, call
+
+# Add mcp/vault to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../mcp/vault'))
+
+from vault_mcp import (
+    derive_agent_key,
+    _decrypt_metadata_impl as decrypt_metadata,
+    _load_master_key,
+    rate_limiter,
+)
+import vault_mcp
+
+VALID_TOKEN = "TOKEN-FOR-DEMONSTRATION-PURPOSES-ONLY-DO-NOT-USE-IN-PRODUCTION"
+
+
+# =============================================================================
+# derive_agent_key tests
+# =============================================================================
+class TestDeriveAgentKey:
+
+    def test_deterministic(self):
+        """Same inputs must produce the same DEK."""
+        master = b"master-key-bytes-for-testing-1234"
+        dek1 = derive_agent_key(master, "agent-abc")
+        dek2 = derive_agent_key(master, "agent-abc")
+        assert dek1 == dek2
+
+    def test_different_agent_id_different_dek(self):
+        """Different agent_id must produce different DEKs."""
+        master = b"master-key-bytes-for-testing-1234"
+        dek_a = derive_agent_key(master, "agent-aaa")
+        dek_b = derive_agent_key(master, "agent-bbb")
+        assert dek_a != dek_b
+
+    def test_output_is_32_bytes(self):
+        """DEK must be exactly 32 bytes (AES-256)."""
+        master = b"some-master-key"
+        dek = derive_agent_key(master, "any-agent")
+        assert isinstance(dek, bytes)
+        assert len(dek) == 32
+
+    def test_different_master_key_different_dek(self):
+        """Different master keys must produce different DEKs for the same agent."""
+        dek1 = derive_agent_key(b"master-key-1", "agent-x")
+        dek2 = derive_agent_key(b"master-key-2", "agent-x")
+        assert dek1 != dek2
+
+
+# =============================================================================
+# _decrypt_metadata_impl tests
+# =============================================================================
+class TestDecryptMetadataImpl:
+
+    @pytest.fixture(autouse=True)
+    def reset_state(self):
+        """Reset rate limiter and master key cache before each test."""
+        rate_limiter._requests.clear()
+        _load_master_key.cache_clear()
+
+    def _make_envelope(self, agent_id: str, ciphertext_b64: str) -> str:
+        """Build a JSON envelope string."""
+        return json.dumps({"a": agent_id, "c": ciphertext_b64})
+
+    def test_per_agent_envelope_decryption(self, monkeypatch):
+        """Per-agent JSON envelope should be parsed and decrypted with derived DEK."""
+        fake_master = b"fake-master-key-32-bytes-long!!!"
+        monkeypatch.setattr('vault_mcp._load_master_key', lambda: fake_master)
+        monkeypatch.setattr('vault_mcp.metadata_key_path', '/fake/MetadataKey.json')
+        # Make metadata_key_path exist check pass
+        monkeypatch.setattr('os.path.exists', lambda p: True)
+
+        expected_dek = derive_agent_key(fake_master, "agent123")
+        mock_decrypt = MagicMock(return_value=b'{"text": "hello"}')
+        monkeypatch.setattr('vault_mcp.aes_decrypt_metadata', mock_decrypt)
+
+        envelope = self._make_envelope("agent123", "Y2lwaGVydGV4dA==")
+        result = decrypt_metadata(VALID_TOKEN, [envelope])
+        data = json.loads(result)
+
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0] == '{"text": "hello"}'
+
+        # Verify aes_decrypt_metadata was called with the ciphertext and derived DEK
+        mock_decrypt.assert_called_once_with("Y2lwaGVydGV4dA==", expected_dek)
+
+    def test_legacy_fallback(self, monkeypatch):
+        """Plain base64 (non-JSON) should fall back to master metadata key."""
+        fake_master = b"fake-master-key-32-bytes-long!!!"
+        monkeypatch.setattr('vault_mcp._load_master_key', lambda: fake_master)
+        monkeypatch.setattr('vault_mcp.metadata_key_path', '/fake/MetadataKey.json')
+        monkeypatch.setattr('os.path.exists', lambda p: True)
+
+        mock_decrypt = MagicMock(return_value=b'legacy plaintext')
+        monkeypatch.setattr('vault_mcp.aes_decrypt_metadata', mock_decrypt)
+
+        # Plain base64 string — not valid JSON envelope
+        legacy_blob = base64.b64encode(b"some-encrypted-data").decode()
+        result = decrypt_metadata(VALID_TOKEN, [legacy_blob])
+        data = json.loads(result)
+
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0] == "legacy plaintext"
+
+        # Should have been called with the raw blob and the metadata_key_path
+        mock_decrypt.assert_called_once_with(legacy_blob, '/fake/MetadataKey.json')
+
+    def test_missing_key_in_envelope_triggers_fallback(self, monkeypatch):
+        """JSON without 'a' or 'c' key should fall back to legacy path."""
+        fake_master = b"fake-master-key-32-bytes-long!!!"
+        monkeypatch.setattr('vault_mcp._load_master_key', lambda: fake_master)
+        monkeypatch.setattr('vault_mcp.metadata_key_path', '/fake/MetadataKey.json')
+        monkeypatch.setattr('os.path.exists', lambda p: True)
+
+        mock_decrypt = MagicMock(return_value=b'fallback result')
+        monkeypatch.setattr('vault_mcp.aes_decrypt_metadata', mock_decrypt)
+
+        # Valid JSON but missing expected keys
+        bad_envelope = json.dumps({"x": "y"})
+        result = decrypt_metadata(VALID_TOKEN, [bad_envelope])
+        data = json.loads(result)
+
+        assert data[0] == "fallback result"
+        mock_decrypt.assert_called_once_with(bad_envelope, '/fake/MetadataKey.json')
+
+    def test_mixed_envelope_and_legacy(self, monkeypatch):
+        """A list mixing per-agent envelopes and legacy blobs should handle both."""
+        fake_master = b"fake-master-key-32-bytes-long!!!"
+        monkeypatch.setattr('vault_mcp._load_master_key', lambda: fake_master)
+        monkeypatch.setattr('vault_mcp.metadata_key_path', '/fake/MetadataKey.json')
+        monkeypatch.setattr('os.path.exists', lambda p: True)
+
+        expected_dek = derive_agent_key(fake_master, "agentABC")
+
+        def side_effect(ct, key):
+            if isinstance(key, bytes):
+                return b'per-agent result'
+            return b'legacy result'
+
+        mock_decrypt = MagicMock(side_effect=side_effect)
+        monkeypatch.setattr('vault_mcp.aes_decrypt_metadata', mock_decrypt)
+
+        envelope = self._make_envelope("agentABC", "ZW5jcnlwdGVk")
+        legacy_blob = "cGxhaW4tYjY0"  # not valid JSON
+
+        result = decrypt_metadata(VALID_TOKEN, [envelope, legacy_blob])
+        data = json.loads(result)
+
+        assert len(data) == 2
+        assert data[0] == "per-agent result"
+        assert data[1] == "legacy result"
+
+    def test_metadata_key_not_found(self, monkeypatch):
+        """Missing MetadataKey file should return error."""
+        monkeypatch.setattr('vault_mcp.metadata_key_path', '/nonexistent/MetadataKey.json')
+        _load_master_key.cache_clear()
+
+        result = decrypt_metadata(VALID_TOKEN, ["anything"])
+        data = json.loads(result)
+
+        assert "error" in data
+        assert "MetadataKey not found" in data["error"]
+
+    def test_invalid_token_rejected(self):
+        """Invalid token should raise ValueError."""
+        with pytest.raises(ValueError, match="Access Denied"):
+            decrypt_metadata("bad-token", ["anything"])
+
+    def test_decryption_error_returns_error(self, monkeypatch):
+        """If aes_decrypt_metadata raises, should return error JSON."""
+        fake_master = b"fake-master-key-32-bytes-long!!!"
+        monkeypatch.setattr('vault_mcp._load_master_key', lambda: fake_master)
+        monkeypatch.setattr('vault_mcp.metadata_key_path', '/fake/MetadataKey.json')
+        monkeypatch.setattr('os.path.exists', lambda p: True)
+
+        mock_decrypt = MagicMock(side_effect=Exception("decrypt boom"))
+        monkeypatch.setattr('vault_mcp.aes_decrypt_metadata', mock_decrypt)
+
+        envelope = self._make_envelope("agent1", "ct_data")
+        result = decrypt_metadata(VALID_TOKEN, [envelope])
+        data = json.loads(result)
+
+        assert "error" in data
+        assert "decrypt boom" in data["error"]

--- a/tests/unit/test_public_key.py
+++ b/tests/unit/test_public_key.py
@@ -24,78 +24,84 @@ class TestGetPublicKey:
     def reset_rate_limiter(self):
         """Reset rate limiter before each test."""
         rate_limiter._requests.clear()
-    """Test get_public_key MCP tool."""
-    
+
     @pytest.fixture(scope="class")
     def test_keys(self):
         """Generate test keys."""
         temp_dir = tempfile.mkdtemp(prefix="test_pubkey_")
         keygen = KeyGenerator(key_path=temp_dir, key_id="test-pubkey", dim_list=[1024])
         keygen.generate_keys()
-        
+
         yield temp_dir
         shutil.rmtree(temp_dir, ignore_errors=True)
+
+    @pytest.fixture(autouse=True)
+    def patch_vault_paths(self, test_keys, monkeypatch):
+        """Patch vault paths to point to test-generated keys."""
+        # KeyGenerator creates files directly in key_path (not in a subdirectory)
+        monkeypatch.setattr('vault_mcp.KEY_SUBDIR', test_keys)
+        monkeypatch.setattr('vault_mcp.metadata_key_path',
+                            os.path.join(test_keys, "MetadataKey.json"))
+        # Mock _load_master_key so it doesn't hit real get_key_stream
+        vault_mcp._load_master_key.cache_clear()
+        monkeypatch.setattr('vault_mcp._load_master_key',
+                            lambda: b'test-master-key-for-public-key!!')
     
-    def test_valid_token_returns_bundle(self, test_keys, monkeypatch):
+    def test_valid_token_returns_bundle(self, test_keys):
         """Valid token should return public key bundle."""
-        monkeypatch.setattr('vault_mcp.KEY_DIR', test_keys)
-        
         result = get_public_key("TOKEN-FOR-DEMONSTRATION-PURPOSES-ONLY-DO-NOT-USE-IN-PRODUCTION")
-        
+
         # Should be valid JSON
         bundle = json.loads(result)
-        
+
         # Should contain public keys
         assert "EncKey.json" in bundle
         assert "EvalKey.json" in bundle
-        
+
         # Should NOT contain secret keys
         assert "SecKey.json" not in bundle
         assert "MetadataKey.json" not in bundle
     
-    def test_invalid_token_raises_error(self, test_keys, monkeypatch):
+    def test_invalid_token_raises_error(self, test_keys):
         """Invalid token should raise ValueError."""
-        monkeypatch.setattr('vault_mcp.KEY_DIR', test_keys)
-        
         with pytest.raises(ValueError, match="Access Denied"):
             get_public_key("invalid-token")
     
-    def test_returned_keys_are_valid_json(self, test_keys, monkeypatch):
-        """Each key in bundle should be valid JSON."""
-        monkeypatch.setattr('vault_mcp.KEY_DIR', test_keys)
-        
+    def test_returned_keys_are_valid_json(self, test_keys):
+        """Each key file in bundle should be valid JSON."""
         result = get_public_key("TOKEN-FOR-DEMONSTRATION-PURPOSES-ONLY-DO-NOT-USE-IN-PRODUCTION")
         bundle = json.loads(result)
-        
-        for key_name, key_content in bundle.items():
-            # Each key should be parseable JSON
+
+        # Only validate actual key file fields; skip non-file fields
+        key_file_fields = {"EncKey.json", "EvalKey.json"}
+        for key_name in key_file_fields:
+            if key_name not in bundle:
+                continue
             try:
-                json.loads(key_content)
+                json.loads(bundle[key_name])
             except json.JSONDecodeError:
                 pytest.fail(f"{key_name} is not valid JSON")
     
     def test_missing_key_file_handled(self, test_keys, monkeypatch):
         """Missing key files should be handled gracefully."""
         temp_dir = tempfile.mkdtemp(prefix="test_missing_")
-        monkeypatch.setattr('vault_mcp.KEY_DIR', temp_dir)
-        
+        monkeypatch.setattr('vault_mcp.KEY_SUBDIR', temp_dir)
+
         # Create only EncKey
         with open(os.path.join(temp_dir, "EncKey.json"), "w") as f:
             f.write('{"test": "key"}')
-        
+
         result = get_public_key("TOKEN-FOR-DEMONSTRATION-PURPOSES-ONLY-DO-NOT-USE-IN-PRODUCTION")
         bundle = json.loads(result)
-        
+
         # Should have EncKey but not others
         assert "EncKey.json" in bundle
         # Others may or may not be present (implementation dependent)
-        
+
         shutil.rmtree(temp_dir, ignore_errors=True)
     
-    def test_bundle_size_reasonable(self, test_keys, monkeypatch):
+    def test_bundle_size_reasonable(self, test_keys):
         """Bundle size should be reasonable (not empty, not too large)."""
-        monkeypatch.setattr('vault_mcp.KEY_DIR', test_keys)
-        
         result = get_public_key("TOKEN-FOR-DEMONSTRATION-PURPOSES-ONLY-DO-NOT-USE-IN-PRODUCTION")
         
         # Should have some content
@@ -104,20 +110,16 @@ class TestGetPublicKey:
         # Should not be excessively large (keys are typically < 1MB each)
         assert len(result) < 10 * 1024 * 1024  # 10MB limit
     
-    def test_multiple_calls_return_same_keys(self, test_keys, monkeypatch):
+    def test_multiple_calls_return_same_keys(self, test_keys):
         """Multiple calls should return consistent keys."""
-        monkeypatch.setattr('vault_mcp.KEY_DIR', test_keys)
-        
         result1 = get_public_key("TOKEN-FOR-DEMONSTRATION-PURPOSES-ONLY-DO-NOT-USE-IN-PRODUCTION")
         result2 = get_public_key("TOKEN-FOR-DEMONSTRATION-PURPOSES-ONLY-DO-NOT-USE-IN-PRODUCTION")
         
         # Should be identical
         assert result1 == result2
     
-    def test_different_calls_return_same_keys(self, test_keys, monkeypatch):
+    def test_different_calls_return_same_keys(self, test_keys):
         """Multiple calls with same token should return same keys (shared vault)."""
-        monkeypatch.setattr('vault_mcp.KEY_DIR', test_keys)
-
         result1 = get_public_key("TOKEN-FOR-DEMONSTRATION-PURPOSES-ONLY-DO-NOT-USE-IN-PRODUCTION")
         result2 = get_public_key("TOKEN-FOR-DEMONSTRATION-PURPOSES-ONLY-DO-NOT-USE-IN-PRODUCTION")
 


### PR DESCRIPTION
Vault now derives per-agent AES-256 DEKs via HMAC-SHA256(master_key, agent_id) and includes key_id, agent_id, agent_dek in the public key bundle.  Metadata decryption updated to resolve agent DEK from the per-agent envelope format {"a": agent_id, "c": ciphertext}.

- Add derive_agent_key() using HMAC-SHA256
- Disable SDK-level metadata_encryption on index creation
- Update _decrypt_metadata_impl for per-agent blob format