### PR TITLE
ci: add Docker image publish workflow for GHCR

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,56 @@
+name: Build and Push Docker Image
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: cryptolabinc/rune-vault
+
+jobs:
+  build-and-push:
+    runs-on: [self-hosted, linux, no-gpu]
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern=v{{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: vault/
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow (`.github/workflows/docker-publish.yml`) that builds and pushes `ghcr.io/cryptolabinc/rune-vault` Docker image on release publish
- Multi-arch support (`linux/amd64`, `linux/arm64`) via QEMU + Buildx
- Semver tags (`{{version}}`, `v{{version}}`, `{{major}}.{{minor}}`) + `latest` gated on default branch
- Uses built-in `GITHUB_TOKEN` — no manual secrets needed
- GHA cache for faster rebuilds

> [!CAUTION]
> **Merge 전 Repository 설정 변경 필요:**
> Repository → Settings → Actions → General → Workflow permissions → **"Read and write permissions"** 선택 필수.
> 이 설정이 없으면 GHCR push 시 `packages: write` 권한 부족으로 실패합니다.

## Test plan
- [ ] Push workflow to branch and create a test pre-release (e.g., `v0.0.1-test`)
- [ ] Verify Actions run triggers and completes
- [ ] Check `ghcr.io/cryptolabinc/rune-vault` for expected tags
- [ ] Test `docker pull` on both amd64 and arm64
- [ ] Delete test release/tag and image after verification

Closes #30