### PR TITLE
feat: per-user token auth for Vault

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -366,7 +366,7 @@ prompt_csp_config() {
 }
 
 generate_team_secret() {
-    VAULT_TEAM_SECRET_VALUE="evt_$(openssl rand -hex 16)"
+    VAULT_TEAM_SECRET_VALUE="evt_$(openssl rand -hex 32)"
     print_info "Team secret generated."
 }
 

--- a/tests/unit/test_crypto.py
+++ b/tests/unit/test_crypto.py
@@ -29,56 +29,59 @@ class TestKeyGeneration:
     
     def test_ensure_vault_creates_directory(self, temp_key_dir, monkeypatch):
         """ensure_vault should create key directory if not exists."""
+        key_subdir = os.path.join(temp_key_dir, KEY_ID)
         monkeypatch.setattr('vault_core.KEY_DIR', temp_key_dir)
-        
+        monkeypatch.setattr('vault_core.KEY_SUBDIR', key_subdir)
+
         # Remove directory to test creation
         if os.path.exists(temp_key_dir):
             shutil.rmtree(temp_key_dir)
-        
+
         # Mock KeyGenerator to avoid actual key generation
         class MockKeyGenerator:
-            def __init__(self, key_path, key_id, dim_list):
+            def __init__(self, key_path, key_id, dim_list, metadata_encryption=None):
                 self.key_path = key_path
                 os.makedirs(key_path, exist_ok=True)
-            
+
             def generate_keys(self):
-                # Create dummy key files
-                for key_name in ["EncKey.json", "SecKey.json", "EvalKey.json", "MetadataKey.json"]:
+                # Create dummy key files (no MetadataKey — metadata_encryption=False)
+                for key_name in ["EncKey.json", "SecKey.json", "EvalKey.json"]:
                     with open(os.path.join(self.key_path, key_name), "w") as f:
                         f.write('{"test": "key"}')
-        
+
         monkeypatch.setattr('vault_core.KeyGenerator', MockKeyGenerator)
-        
-        # Import with mocked KeyGenerator
+
         from vault_core import ensure_vault as ensure_vault_test
         ensure_vault_test()
-        
-        assert os.path.exists(temp_key_dir)
+
+        assert os.path.exists(key_subdir)
     
     def test_ensure_vault_finds_existing_keys(self, temp_key_dir, monkeypatch):
         """ensure_vault should detect existing keys."""
+        key_subdir = os.path.join(temp_key_dir, KEY_ID)
         monkeypatch.setattr('vault_core.KEY_DIR', temp_key_dir)
+        monkeypatch.setattr('vault_core.KEY_SUBDIR', key_subdir)
 
-        # Create directory and dummy keys
-        os.makedirs(temp_key_dir, exist_ok=True)
+        # Create directory and dummy keys in KEY_SUBDIR
+        os.makedirs(key_subdir, exist_ok=True)
         for key_name in ["EncKey.json", "SecKey.json"]:
-            Path(os.path.join(temp_key_dir, key_name)).touch()
+            Path(os.path.join(key_subdir, key_name)).touch()
 
         # Should log "Keys found" via logger.info (not print)
         import logging
         from vault_core import ensure_vault as ensure_vault_test
         with patch('vault_core.logger') as mock_logger:
             ensure_vault_test()
-            mock_logger.info.assert_any_call(f"Keys found in {temp_key_dir}")
+            mock_logger.info.assert_any_call(f"Keys found in {key_subdir}")
     
     def test_key_files_have_correct_names(self, temp_key_dir):
         """Generated keys should have standard names."""
-        expected_keys = ["EncKey.json", "SecKey.json", "EvalKey.json", "MetadataKey.json"]
-        
-        # Generate real keys (dimension 1024)
-        keygen = KeyGenerator(key_path=temp_key_dir, key_id="test-key", dim_list=[1024])
+        expected_keys = ["EncKey.json", "SecKey.json", "EvalKey.json"]
+
+        # Generate real keys (dimension 1024, no MetadataKey)
+        keygen = KeyGenerator(key_path=temp_key_dir, key_id="test-key", dim_list=[1024], metadata_encryption=False)
         keygen.generate_keys()
-        
+
         for key_file in expected_keys:
             assert os.path.exists(os.path.join(temp_key_dir, key_file)), f"{key_file} not generated"
 

--- a/tests/unit/test_decrypt_scores.py
+++ b/tests/unit/test_decrypt_scores.py
@@ -18,7 +18,8 @@ from unittest.mock import MagicMock, patch
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../vault'))
 
 # Import the implementation function (not the MCP-decorated version)
-from vault_core import _decrypt_scores_impl as decrypt_scores, rate_limiter
+from vault_core import _decrypt_scores_impl as decrypt_scores
+from token_store import token_store
 
 
 def _make_fake_blob() -> str:
@@ -40,8 +41,8 @@ class TestDecryptScores:
 
     @pytest.fixture(autouse=True)
     def reset_rate_limiter(self):
-        """Reset rate limiter before each test."""
-        rate_limiter._requests.clear()
+        """Reset rate limiters before each test."""
+        token_store._rate_limiters.clear()
 
     def _patch_cipher_and_proto(self, monkeypatch, scores_return):
         """Helper to mock cipher, CiphertextScore, and CipherBlock."""
@@ -119,20 +120,24 @@ class TestDecryptScores:
         assert returned_scores[1] == pytest.approx(0.8)
 
     def test_top_k_limit_enforced(self):
-        """Top-K > 10 should be rejected (policy)."""
+        """Top-K exceeding role limit should be rejected."""
+        from token_store import TopKExceededError, token_store as ts
+
+        # Issue a member token (top_k=10) to test limit enforcement
+        tok = ts.add_token("topk-test-user", "member")
         blob = _make_fake_blob()
 
-        result = decrypt_scores("TOKEN-FOR-DEMONSTRATION-PURPOSES-ONLY-DO-NOT-USE-IN-PRODUCTION", blob, top_k=15)
-        data = json.loads(result)
+        with pytest.raises(TopKExceededError):
+            decrypt_scores(tok.token, blob, top_k=15)
 
-        assert "error" in data
-        assert "Rate Limit" in data["error"] or "Max top_k" in data["error"]
+        ts.revoke_token("topk-test-user")
 
     def test_invalid_token_rejected(self):
-        """Invalid token should raise ValueError."""
+        """Invalid token should raise an authentication error."""
+        from token_store import TokenNotFoundError
         blob = _make_fake_blob()
 
-        with pytest.raises(ValueError, match="Access Denied"):
+        with pytest.raises(TokenNotFoundError):
             decrypt_scores("invalid-token", blob, top_k=5)
 
     def test_malformed_blob_returns_error(self):

--- a/tests/unit/test_metadata_dek.py
+++ b/tests/unit/test_metadata_dek.py
@@ -2,15 +2,14 @@
 Unit tests for per-agent metadata DEK derivation and decrypt_metadata.
 
 Uses mock-based approach: aes_decrypt_metadata is mocked to test the
-envelope parsing, per-agent key derivation, and legacy fallback logic
-without requiring real FHE keys.
+envelope parsing and per-agent HKDF key derivation without requiring
+real FHE keys.
 """
 import pytest
 import sys
 import os
 import json
-import base64
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock
 
 # Add vault to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../vault'))
@@ -18,12 +17,12 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../vault'))
 from vault_core import (
     derive_agent_key,
     _decrypt_metadata_impl as decrypt_metadata,
-    _load_master_key,
-    rate_limiter,
 )
 import vault_core
+from token_store import token_store
 
 VALID_TOKEN = "TOKEN-FOR-DEMONSTRATION-PURPOSES-ONLY-DO-NOT-USE-IN-PRODUCTION"
+FAKE_TEAM_SECRET = "evt_fake-team-secret-for-testing-purposes-only"
 
 
 # =============================================================================
@@ -33,29 +32,26 @@ class TestDeriveAgentKey:
 
     def test_deterministic(self):
         """Same inputs must produce the same DEK."""
-        master = b"master-key-bytes-for-testing-1234"
-        dek1 = derive_agent_key(master, "agent-abc")
-        dek2 = derive_agent_key(master, "agent-abc")
+        dek1 = derive_agent_key("my-team-secret", "agent-abc")
+        dek2 = derive_agent_key("my-team-secret", "agent-abc")
         assert dek1 == dek2
 
     def test_different_agent_id_different_dek(self):
         """Different agent_id must produce different DEKs."""
-        master = b"master-key-bytes-for-testing-1234"
-        dek_a = derive_agent_key(master, "agent-aaa")
-        dek_b = derive_agent_key(master, "agent-bbb")
+        dek_a = derive_agent_key("my-team-secret", "agent-aaa")
+        dek_b = derive_agent_key("my-team-secret", "agent-bbb")
         assert dek_a != dek_b
 
     def test_output_is_32_bytes(self):
         """DEK must be exactly 32 bytes (AES-256)."""
-        master = b"some-master-key"
-        dek = derive_agent_key(master, "any-agent")
+        dek = derive_agent_key("some-secret", "any-agent")
         assert isinstance(dek, bytes)
         assert len(dek) == 32
 
-    def test_different_master_key_different_dek(self):
-        """Different master keys must produce different DEKs for the same agent."""
-        dek1 = derive_agent_key(b"master-key-1", "agent-x")
-        dek2 = derive_agent_key(b"master-key-2", "agent-x")
+    def test_different_team_secret_different_dek(self):
+        """Different team secrets must produce different DEKs for the same agent."""
+        dek1 = derive_agent_key("secret-1", "agent-x")
+        dek2 = derive_agent_key("secret-2", "agent-x")
         assert dek1 != dek2
 
 
@@ -66,9 +62,8 @@ class TestDecryptMetadataImpl:
 
     @pytest.fixture(autouse=True)
     def reset_state(self):
-        """Reset rate limiter and master key cache before each test."""
-        rate_limiter._requests.clear()
-        _load_master_key.cache_clear()
+        """Reset rate limiters before each test."""
+        token_store._rate_limiters.clear()
 
     def _make_envelope(self, agent_id: str, ciphertext_b64: str) -> str:
         """Build a JSON envelope string."""
@@ -76,13 +71,9 @@ class TestDecryptMetadataImpl:
 
     def test_per_agent_envelope_decryption(self, monkeypatch):
         """Per-agent JSON envelope should be parsed and decrypted with derived DEK."""
-        fake_master = b"fake-master-key-32-bytes-long!!!"
-        monkeypatch.setattr('vault_core._load_master_key', lambda: fake_master)
-        monkeypatch.setattr('vault_core.metadata_key_path', '/fake/MetadataKey.json')
-        # Make metadata_key_path exist check pass
-        monkeypatch.setattr('os.path.exists', lambda p: True)
+        monkeypatch.setattr('vault_core.VAULT_TEAM_SECRET', FAKE_TEAM_SECRET)
 
-        expected_dek = derive_agent_key(fake_master, "agent123")
+        expected_dek = derive_agent_key(FAKE_TEAM_SECRET, "agent123")
         mock_decrypt = MagicMock(return_value=b'{"text": "hello"}')
         monkeypatch.setattr('vault_core.aes_decrypt_metadata', mock_decrypt)
 
@@ -97,95 +88,44 @@ class TestDecryptMetadataImpl:
         # Verify aes_decrypt_metadata was called with the ciphertext and derived DEK
         mock_decrypt.assert_called_once_with("Y2lwaGVydGV4dA==", expected_dek)
 
-    def test_legacy_fallback(self, monkeypatch):
-        """Plain base64 (non-JSON) should fall back to master metadata key."""
-        fake_master = b"fake-master-key-32-bytes-long!!!"
-        monkeypatch.setattr('vault_core._load_master_key', lambda: fake_master)
-        monkeypatch.setattr('vault_core.metadata_key_path', '/fake/MetadataKey.json')
-        monkeypatch.setattr('os.path.exists', lambda p: True)
-
-        mock_decrypt = MagicMock(return_value=b'legacy plaintext')
-        monkeypatch.setattr('vault_core.aes_decrypt_metadata', mock_decrypt)
-
-        # Plain base64 string — not valid JSON envelope
-        legacy_blob = base64.b64encode(b"some-encrypted-data").decode()
-        result = decrypt_metadata(VALID_TOKEN, [legacy_blob])
-        data = json.loads(result)
-
-        assert isinstance(data, list)
-        assert len(data) == 1
-        assert data[0] == "legacy plaintext"
-
-        # Should have been called with the raw blob and the metadata_key_path
-        mock_decrypt.assert_called_once_with(legacy_blob, '/fake/MetadataKey.json')
-
-    def test_missing_key_in_envelope_triggers_fallback(self, monkeypatch):
-        """JSON without 'a' or 'c' key should fall back to legacy path."""
-        fake_master = b"fake-master-key-32-bytes-long!!!"
-        monkeypatch.setattr('vault_core._load_master_key', lambda: fake_master)
-        monkeypatch.setattr('vault_core.metadata_key_path', '/fake/MetadataKey.json')
-        monkeypatch.setattr('os.path.exists', lambda p: True)
-
-        mock_decrypt = MagicMock(return_value=b'fallback result')
-        monkeypatch.setattr('vault_core.aes_decrypt_metadata', mock_decrypt)
-
-        # Valid JSON but missing expected keys
-        bad_envelope = json.dumps({"x": "y"})
-        result = decrypt_metadata(VALID_TOKEN, [bad_envelope])
-        data = json.loads(result)
-
-        assert data[0] == "fallback result"
-        mock_decrypt.assert_called_once_with(bad_envelope, '/fake/MetadataKey.json')
-
-    def test_mixed_envelope_and_legacy(self, monkeypatch):
-        """A list mixing per-agent envelopes and legacy blobs should handle both."""
-        fake_master = b"fake-master-key-32-bytes-long!!!"
-        monkeypatch.setattr('vault_core._load_master_key', lambda: fake_master)
-        monkeypatch.setattr('vault_core.metadata_key_path', '/fake/MetadataKey.json')
-        monkeypatch.setattr('os.path.exists', lambda p: True)
-
-        expected_dek = derive_agent_key(fake_master, "agentABC")
-
-        def side_effect(ct, key):
-            if isinstance(key, bytes):
-                return b'per-agent result'
-            return b'legacy result'
-
-        mock_decrypt = MagicMock(side_effect=side_effect)
-        monkeypatch.setattr('vault_core.aes_decrypt_metadata', mock_decrypt)
-
-        envelope = self._make_envelope("agentABC", "ZW5jcnlwdGVk")
-        legacy_blob = "cGxhaW4tYjY0"  # not valid JSON
-
-        result = decrypt_metadata(VALID_TOKEN, [envelope, legacy_blob])
-        data = json.loads(result)
-
-        assert len(data) == 2
-        assert data[0] == "per-agent result"
-        assert data[1] == "legacy result"
-
-    def test_metadata_key_not_found(self, monkeypatch):
-        """Missing MetadataKey file should return error."""
-        monkeypatch.setattr('vault_core.metadata_key_path', '/nonexistent/MetadataKey.json')
-        _load_master_key.cache_clear()
+    def test_missing_team_secret_returns_error(self, monkeypatch):
+        """Missing VAULT_TEAM_SECRET should return error."""
+        monkeypatch.setattr('vault_core.VAULT_TEAM_SECRET', '')
 
         result = decrypt_metadata(VALID_TOKEN, ["anything"])
         data = json.loads(result)
 
         assert "error" in data
-        assert "MetadataKey not found" in data["error"]
+        assert "VAULT_TEAM_SECRET not configured" in data["error"]
 
     def test_invalid_token_rejected(self):
-        """Invalid token should raise ValueError."""
-        with pytest.raises(ValueError, match="Access Denied"):
+        """Invalid token should raise an authentication error."""
+        from token_store import TokenNotFoundError
+        with pytest.raises(TokenNotFoundError):
             decrypt_metadata("bad-token", ["anything"])
+
+    def test_invalid_envelope_returns_error(self, monkeypatch):
+        """Non-JSON envelope should return a decryption error."""
+        monkeypatch.setattr('vault_core.VAULT_TEAM_SECRET', FAKE_TEAM_SECRET)
+
+        result = decrypt_metadata(VALID_TOKEN, ["not-valid-json"])
+        data = json.loads(result)
+
+        assert "error" in data
+
+    def test_missing_key_in_envelope_returns_error(self, monkeypatch):
+        """JSON without 'a' or 'c' key should return a decryption error."""
+        monkeypatch.setattr('vault_core.VAULT_TEAM_SECRET', FAKE_TEAM_SECRET)
+
+        bad_envelope = json.dumps({"x": "y"})
+        result = decrypt_metadata(VALID_TOKEN, [bad_envelope])
+        data = json.loads(result)
+
+        assert "error" in data
 
     def test_decryption_error_returns_error(self, monkeypatch):
         """If aes_decrypt_metadata raises, should return error JSON."""
-        fake_master = b"fake-master-key-32-bytes-long!!!"
-        monkeypatch.setattr('vault_core._load_master_key', lambda: fake_master)
-        monkeypatch.setattr('vault_core.metadata_key_path', '/fake/MetadataKey.json')
-        monkeypatch.setattr('os.path.exists', lambda p: True)
+        monkeypatch.setattr('vault_core.VAULT_TEAM_SECRET', FAKE_TEAM_SECRET)
 
         mock_decrypt = MagicMock(side_effect=Exception("decrypt boom"))
         monkeypatch.setattr('vault_core.aes_decrypt_metadata', mock_decrypt)
@@ -196,3 +136,29 @@ class TestDecryptMetadataImpl:
 
         assert "error" in data
         assert "decrypt boom" in data["error"]
+
+    def test_multiple_envelopes(self, monkeypatch):
+        """Multiple envelopes with different agent_ids should each derive correct DEK."""
+        monkeypatch.setattr('vault_core.VAULT_TEAM_SECRET', FAKE_TEAM_SECRET)
+
+        dek_a = derive_agent_key(FAKE_TEAM_SECRET, "agentA")
+        dek_b = derive_agent_key(FAKE_TEAM_SECRET, "agentB")
+
+        def side_effect(ct, key):
+            if key == dek_a:
+                return b'result-a'
+            if key == dek_b:
+                return b'result-b'
+            return b'unknown'
+
+        mock_decrypt = MagicMock(side_effect=side_effect)
+        monkeypatch.setattr('vault_core.aes_decrypt_metadata', mock_decrypt)
+
+        env_a = self._make_envelope("agentA", "ct_a")
+        env_b = self._make_envelope("agentB", "ct_b")
+        result = decrypt_metadata(VALID_TOKEN, [env_a, env_b])
+        data = json.loads(result)
+
+        assert len(data) == 2
+        assert data[0] == "result-a"
+        assert data[1] == "result-b"

--- a/tests/unit/test_public_key.py
+++ b/tests/unit/test_public_key.py
@@ -13,23 +13,26 @@ from pathlib import Path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../vault'))
 
 # Import the implementation function
-from vault_core import _get_public_key_impl as get_public_key, rate_limiter
+from vault_core import _get_public_key_impl as get_public_key
 import vault_core
+from token_store import token_store
 from pyenvector.crypto import KeyGenerator
+
+FAKE_TEAM_SECRET = "evt_fake-team-secret-for-testing-purposes-only"
 
 
 class TestGetPublicKey:
 
     @pytest.fixture(autouse=True)
     def reset_rate_limiter(self):
-        """Reset rate limiter before each test."""
-        rate_limiter._requests.clear()
+        """Reset rate limiters before each test."""
+        token_store._rate_limiters.clear()
 
     @pytest.fixture(scope="class")
     def test_keys(self):
         """Generate test keys."""
         temp_dir = tempfile.mkdtemp(prefix="test_pubkey_")
-        keygen = KeyGenerator(key_path=temp_dir, key_id="test-pubkey", dim_list=[1024])
+        keygen = KeyGenerator(key_path=temp_dir, key_id="test-pubkey", dim_list=[1024], metadata_encryption=False)
         keygen.generate_keys()
 
         yield temp_dir
@@ -38,15 +41,9 @@ class TestGetPublicKey:
     @pytest.fixture(autouse=True)
     def patch_vault_paths(self, test_keys, monkeypatch):
         """Patch vault paths to point to test-generated keys."""
-        # KeyGenerator creates files directly in key_path (not in a subdirectory)
         monkeypatch.setattr('vault_core.KEY_SUBDIR', test_keys)
-        monkeypatch.setattr('vault_core.metadata_key_path',
-                            os.path.join(test_keys, "MetadataKey.json"))
-        # Mock _load_master_key so it doesn't hit real get_key_stream
-        vault_core._load_master_key.cache_clear()
-        monkeypatch.setattr('vault_core._load_master_key',
-                            lambda: b'test-master-key-for-public-key!!')
-    
+        monkeypatch.setattr('vault_core.VAULT_TEAM_SECRET', FAKE_TEAM_SECRET)
+
     def test_valid_token_returns_bundle(self, test_keys):
         """Valid token should return public key bundle."""
         result = get_public_key("TOKEN-FOR-DEMONSTRATION-PURPOSES-ONLY-DO-NOT-USE-IN-PRODUCTION")
@@ -61,12 +58,13 @@ class TestGetPublicKey:
         # Should NOT contain secret keys
         assert "SecKey.json" not in bundle
         assert "MetadataKey.json" not in bundle
-    
+
     def test_invalid_token_raises_error(self, test_keys):
-        """Invalid token should raise ValueError."""
-        with pytest.raises(ValueError, match="Access Denied"):
+        """Invalid token should raise an authentication error."""
+        from token_store import TokenNotFoundError
+        with pytest.raises(TokenNotFoundError):
             get_public_key("invalid-token")
-    
+
     def test_returned_keys_are_valid_json(self, test_keys):
         """Each key file in bundle should be valid JSON."""
         result = get_public_key("TOKEN-FOR-DEMONSTRATION-PURPOSES-ONLY-DO-NOT-USE-IN-PRODUCTION")
@@ -81,7 +79,7 @@ class TestGetPublicKey:
                 json.loads(bundle[key_name])
             except json.JSONDecodeError:
                 pytest.fail(f"{key_name} is not valid JSON")
-    
+
     def test_missing_key_file_handled(self, test_keys, monkeypatch):
         """Missing key files should be handled gracefully."""
         temp_dir = tempfile.mkdtemp(prefix="test_missing_")
@@ -99,29 +97,30 @@ class TestGetPublicKey:
         # Others may or may not be present (implementation dependent)
 
         shutil.rmtree(temp_dir, ignore_errors=True)
-    
+
     def test_bundle_size_reasonable(self, test_keys):
         """Bundle size should be reasonable (not empty, not too large)."""
         result = get_public_key("TOKEN-FOR-DEMONSTRATION-PURPOSES-ONLY-DO-NOT-USE-IN-PRODUCTION")
-        
+
         # Should have some content
         assert len(result) > 100
-        
+
         # Should not be excessively large (keys are typically < 1MB each)
         assert len(result) < 10 * 1024 * 1024  # 10MB limit
-    
+
     def test_multiple_calls_return_same_keys(self, test_keys):
         """Multiple calls should return consistent keys."""
         result1 = get_public_key("TOKEN-FOR-DEMONSTRATION-PURPOSES-ONLY-DO-NOT-USE-IN-PRODUCTION")
         result2 = get_public_key("TOKEN-FOR-DEMONSTRATION-PURPOSES-ONLY-DO-NOT-USE-IN-PRODUCTION")
-        
+
         # Should be identical
         assert result1 == result2
-    
-    def test_different_calls_return_same_keys(self, test_keys):
-        """Multiple calls with same token should return same keys (shared vault)."""
-        result1 = get_public_key("TOKEN-FOR-DEMONSTRATION-PURPOSES-ONLY-DO-NOT-USE-IN-PRODUCTION")
-        result2 = get_public_key("TOKEN-FOR-DEMONSTRATION-PURPOSES-ONLY-DO-NOT-USE-IN-PRODUCTION")
 
-        # Keys should be identical (same vault)
-        assert result1 == result2
+    def test_bundle_contains_agent_id_and_dek(self, test_keys):
+        """Bundle should contain per-user agent_id and agent_dek."""
+        result = get_public_key("TOKEN-FOR-DEMONSTRATION-PURPOSES-ONLY-DO-NOT-USE-IN-PRODUCTION")
+        bundle = json.loads(result)
+
+        assert "agent_id" in bundle
+        assert "agent_dek" in bundle
+        assert len(bundle["agent_id"]) == 32  # SHA256 hex[:32]

--- a/tests/unit/test_token_store.py
+++ b/tests/unit/test_token_store.py
@@ -1,6 +1,7 @@
 """
 Unit tests for TokenStore: per-user token management, role CRUD, persistence.
 """
+import copy
 import datetime
 import os
 import sys
@@ -13,7 +14,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../vault'))
 from token_store import (
     TokenStore, Role, Token, RateLimiter,
     TokenNotFoundError, TokenExpiredError, RateLimitError,
-    TopKExceededError, ScopeError, DEFAULT_ROLES,
+    TopKExceededError, ScopeError,
 )
 
 
@@ -22,7 +23,10 @@ class TestTokenStore:
 
     def setup_method(self):
         self.store = TokenStore()
-        self.store._roles = dict(DEFAULT_ROLES)
+        self.store._roles = {
+            "admin": Role("admin", ["get_public_key", "decrypt_scores", "decrypt_metadata", "manage_tokens"], 50, "150/60s"),
+            "member": Role("member", ["get_public_key", "decrypt_scores", "decrypt_metadata"], 10, "30/60s"),
+        }
 
     def test_add_and_validate_token(self):
         tok = self.store.add_token("alice", "member", expires_days=90)
@@ -140,7 +144,10 @@ class TestRoleCRUD:
 
     def setup_method(self):
         self.store = TokenStore()
-        self.store._roles = dict(DEFAULT_ROLES)
+        self.store._roles = {
+            "admin": Role("admin", ["get_public_key", "decrypt_scores", "decrypt_metadata", "manage_tokens"], 50, "150/60s"),
+            "member": Role("member", ["get_public_key", "decrypt_scores", "decrypt_metadata"], 10, "30/60s"),
+        }
 
     def test_create_role(self):
         role = self.store.add_role(

--- a/vault/requirements.txt
+++ b/vault/requirements.txt
@@ -11,6 +11,9 @@ psutil>=5.9.0
 # Token Management
 PyYAML>=6.0
 
+# Cryptography (HKDF key derivation)
+cryptography>=41.0.0
+
 # gRPC
 grpcio>=1.60.2,<=1.74.0
 grpcio-tools>=1.60.2,<=1.74.0

--- a/vault/vault_core.py
+++ b/vault/vault_core.py
@@ -6,15 +6,15 @@ No transport layer (MCP, gRPC) — consumed by vault_grpc_server.py.
 """
 
 import base64
-import functools
 import hashlib
 import heapq
-import hmac
 import logging
 import os
 import json
 
 logger = logging.getLogger("rune.vault")
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives import hashes
 from pyenvector.crypto import KeyGenerator, Cipher
 from pyenvector.crypto.block import CipherBlock, Query
 from pyenvector.utils.aes import decrypt_metadata as aes_decrypt_metadata
@@ -64,7 +64,7 @@ def ensure_vault():
     if not os.path.exists(enc_key):
         logger.info(f"Generating keys in {KEY_SUBDIR}...")
         os.makedirs(KEY_SUBDIR, exist_ok=True)
-        keygen = KeyGenerator(key_path=KEY_SUBDIR, key_id=KEY_ID, dim_list=[DIM])
+        keygen = KeyGenerator(key_path=KEY_SUBDIR, key_id=KEY_ID, dim_list=[DIM], metadata_encryption=False)
         keygen.generate_keys()
     else:
         logger.info(f"Keys found in {KEY_SUBDIR}")
@@ -131,23 +131,30 @@ def ensure_vault():
 ensure_vault()
 enc_key_path = os.path.join(KEY_SUBDIR, "EncKey.json")
 sec_key_path = os.path.join(KEY_SUBDIR, "SecKey.json")
-metadata_key_path = os.path.join(KEY_SUBDIR, "MetadataKey.json")
 
 # Initialize shared Cipher instance
 cipher = Cipher(enc_key_path=enc_key_path, dim=DIM)
 
 # =============================================================================
-# Per-Agent Metadata Key Derivation
+# Per-Agent Metadata Key Derivation (HKDF-SHA256)
 # =============================================================================
-@functools.lru_cache(maxsize=1)
-def _load_master_key() -> bytes:
-    """Load MetadataKey as master key for per-agent DEK derivation."""
-    from pyenvector.utils.utils import get_key_stream
-    return get_key_stream(metadata_key_path)
+def derive_agent_key(team_secret: str, agent_id: str) -> bytes:
+    """Derive a 32-byte AES-256 DEK for a specific agent via HKDF-SHA256.
 
-def derive_agent_key(master_key: bytes, agent_id: str) -> bytes:
-    """Derive a 32-byte AES-256 DEK for a specific agent via HMAC-SHA256."""
-    return hmac.new(master_key, agent_id.encode('utf-8'), hashlib.sha256).digest()
+    Args:
+        team_secret: Team-wide master secret (VAULT_TEAM_SECRET).
+        agent_id: Per-user agent identifier derived from token.
+
+    Returns:
+        32-byte AES-256 key.
+    """
+    hkdf = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=None,
+        info=agent_id.encode('utf-8'),
+    )
+    return hkdf.derive(team_secret.encode('utf-8'))
 
 # =============================================================================
 # Authorization (per-user token auth via TokenStore)
@@ -213,12 +220,9 @@ def _get_public_key_impl(token: str) -> str:
         bundle["index_name"] = VAULT_INDEX_NAME
     bundle["key_id"] = KEY_ID
 
-    # Team-shared metadata DEK: derived from VAULT_TEAM_SECRET (not per-user token)
-    # All team members get the same DEK so they can decrypt each other's metadata
-    dek_source = VAULT_TEAM_SECRET or token
-    agent_id = hashlib.sha256(dek_source.encode('utf-8')).hexdigest()[:32]
-    master_key = _load_master_key()
-    agent_dek = derive_agent_key(master_key, agent_id)
+    # Per-user metadata DEK: derived from VAULT_TEAM_SECRET + token-based agent_id
+    agent_id = hashlib.sha256(token.encode('utf-8')).hexdigest()[:32]
+    agent_dek = derive_agent_key(VAULT_TEAM_SECRET, agent_id)
     bundle["agent_id"] = agent_id
     bundle["agent_dek"] = base64.b64encode(agent_dek).decode('ascii')
 
@@ -288,7 +292,7 @@ def _decrypt_metadata_impl(token: str, encrypted_metadata_list: list[str]) -> st
     Core implementation: Decrypts a list of per-agent AES-encrypted metadata.
 
     Each item is a JSON string: {"a": "<agent_id>", "c": "<base64_ciphertext>"}.
-    Vault derives the agent's DEK from master key + agent_id, then decrypts.
+    Vault derives the agent's DEK from VAULT_TEAM_SECRET + agent_id via HKDF.
 
     Args:
         token: Authentication token issued by Vault Admin.
@@ -300,22 +304,17 @@ def _decrypt_metadata_impl(token: str, encrypted_metadata_list: list[str]) -> st
     username, role = validate_token(token)
     token_store.check_scope(role, "decrypt_metadata")
 
-    if not os.path.exists(metadata_key_path):
-        return json.dumps({"error": "MetadataKey not found in Vault"})
+    if not VAULT_TEAM_SECRET:
+        return json.dumps({"error": "VAULT_TEAM_SECRET not configured"})
 
     try:
-        master_key = _load_master_key()
         results = []
         for blob_str in encrypted_metadata_list:
-            try:
-                blob = json.loads(blob_str)
-                agent_id = blob["a"]
-                ct_b64 = blob["c"]
-                agent_dek = derive_agent_key(master_key, agent_id)
-                decrypted = aes_decrypt_metadata(ct_b64, agent_dek)
-            except (json.JSONDecodeError, KeyError):
-                # Legacy format: plain base64, decrypt with master metadata key
-                decrypted = aes_decrypt_metadata(blob_str, metadata_key_path)
+            blob = json.loads(blob_str)
+            agent_id = blob["a"]
+            ct_b64 = blob["c"]
+            agent_dek = derive_agent_key(VAULT_TEAM_SECRET, agent_id)
+            decrypted = aes_decrypt_metadata(ct_b64, agent_dek)
             if isinstance(decrypted, bytes):
                 decrypted = decrypted.decode('utf-8')
             results.append(decrypted)


### PR DESCRIPTION
## Summary
The last commit `45d294c` from #36 was not reflected in `main`. This PR carries over the missing change:

- Replace HMAC-based DEK derivation with HKDF-SHA256
- Remove `MetadataKey.json` file dependency
- Update related test code

This will now provides each different metadata DEK for members.

Closes #18