### PR TITLE
fix(vault): workaround pyenvector create_index metadata key bug

### DIFF
--- a/vault/vault_core.py
+++ b/vault/vault_core.py
@@ -123,6 +123,7 @@ def ensure_vault():
                 index_params={"index_type": "FLAT"},
                 query_encryption="plain",
                 metadata_encryption=False,
+                metadata_key=b"",  # workaround: skip deepcopy metadata_key property access (pyenvector#247)
             )
             logger.info(f"Created team index '{VAULT_INDEX_NAME}' (dim={EMBEDDING_DIM}).")
     except Exception as e:


### PR DESCRIPTION
## Summary
- Add `metadata_key=b""` parameter to `create_index()` call to work around a pyenvector bug (#247) where `deepcopy` triggers an unintended metadata key property access, causing index creation to fail.

## Test plan
- [x] Verify vault index creation succeeds on fresh deployment
- [x] Confirm existing indexes are unaffected