### PR TITLE
[FIX] Restore install dir ownership in deploy_local()

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -555,6 +555,11 @@ deploy_local() {
     generate_env_file
     generate_config_files "$INSTALL_DIR"
 
+    # Restore ownership to the invoking user (files were created as root via sudo)
+    if [ -n "${SUDO_USER:-}" ]; then
+        chown -R "$SUDO_USER" "$INSTALL_DIR"
+    fi
+
     # Pull image
     print_step "Pulling Docker image..."
     (cd "$INSTALL_DIR" && docker compose pull)


### PR DESCRIPTION
###  Background
  - When `install.sh` is run via `sudo bash install.sh`, all files and directories under `$INSTALL_DIR` are created as root
  - `docker compose` runs as the invoking user(=`$SUDO_USER`)                                                                 

### Problem
- `docker compose` cannot create bind-mount source paths owned by root
  `Error response from daemon: error while creating mount source path '...': mkdir ...: permission denied `                                                                                 
---
### Solution
  - Added a `chown -R "$SUDO_USER" "$INSTALL_DIR"` to the `deploy_local()` function before running `docker compose up` to restore ownership to the user who invoked sudo(=`$SUDO_USER`)