### PR TITLE
fix(installer): fix stale role name and missing shell reload hint

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -775,6 +775,11 @@ show_summary() {
     echo "  Issue per-user tokens with:"
     echo "    runevault token issue --user <name> --role agent --expires 90d"
     echo ""
+    if [ "$DEPLOY_TARGET" = "local" ]; then
+        echo "  Reload your shell before using the runevault command:"
+        echo "    exec \$SHELL"
+        echo ""
+    fi
     echo "  Each team member uses their individual token for authentication."
     echo "  Team Secret (above) is only needed for DEK derivation — keep it secure."
     if [ "$TLS_MODE" = "self-signed" ]; then

--- a/install.sh
+++ b/install.sh
@@ -379,7 +379,7 @@ roles:
     scope: [get_public_key, decrypt_scores, decrypt_metadata, manage_tokens]
     top_k: 50
     rate_limit: 150/60s
-  agent:
+  member:
     scope: [get_public_key, decrypt_scores, decrypt_metadata]
     top_k: 10
     rate_limit: 30/60s
@@ -773,7 +773,7 @@ show_summary() {
     fi
     echo ""
     echo "  Issue per-user tokens with:"
-    echo "    runevault token issue --user <name> --role agent --expires 90d"
+    echo "    runevault token issue --user <name> --role member --expires 90d"
     echo ""
     if [ "$DEPLOY_TARGET" = "local" ]; then
         echo "  Reload your shell before using the runevault command:"

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -781,6 +781,11 @@ show_summary() {
     echo "  Issue per-user tokens with:"
     echo "    runevault token issue --user <name> --role agent --expires 90d"
     echo ""
+    if [ "$DEPLOY_TARGET" = "local" ]; then
+        echo "  Reload your shell before using the runevault command:"
+        echo "    exec \$SHELL"
+        echo ""
+    fi
     echo "  Each team member uses their individual token for authentication."
     echo "  Team Secret (above) is only needed for DEK derivation — keep it secure."
     if [ "$TLS_MODE" = "self-signed" ]; then

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -374,7 +374,7 @@ roles:
     scope: [get_public_key, decrypt_scores, decrypt_metadata, manage_tokens]
     top_k: 50
     rate_limit: 150/60s
-  agent:
+  member:
     scope: [get_public_key, decrypt_scores, decrypt_metadata]
     top_k: 10
     rate_limit: 30/60s
@@ -779,7 +779,7 @@ show_summary() {
     fi
     echo ""
     echo "  Issue per-user tokens with:"
-    echo "    runevault token issue --user <name> --role agent --expires 90d"
+    echo "    runevault token issue --user <name> --role member --expires 90d"
     echo ""
     if [ "$DEPLOY_TARGET" = "local" ]; then
         echo "  Reload your shell before using the runevault command:"

--- a/vault/vault_admin_cli.py
+++ b/vault/vault_admin_cli.py
@@ -3,13 +3,13 @@
 Vault Admin CLI — manages per-user tokens and roles.
 
 Usage (via docker exec or runevault alias):
-    runevault token issue --user alice --role agent --expires 90d
+    runevault token issue --user alice --role member --expires 90d
     runevault token revoke --user alice
     runevault token list
     runevault role list
     runevault role create --name researcher \\
         --scope get_public_key,decrypt_scores --top-k 3 --rate-limit 10/60s
-    runevault role update --name agent --top-k 8
+    runevault role update --name member --top-k 8
     runevault role delete --name researcher
 """
 


### PR DESCRIPTION
## Context
Installer scripts had stale references left over from the agent→member role rename (#18), and the `exec $SHELL` reminder was buried above the final summary output during local deploys.

## TL;DR
Fix outdated `agent` role references in installers/CLI and surface `exec $SHELL` hint in deployment summary.

## Summary

- Rename `agent` → `member` in vault-roles.yml heredocs, token issue examples, and CLI docstring
- Add `exec $SHELL` reminder to `show_summary` for local deployments in both install scripts

## Alternatives

- Could have removed the `exec $SHELL` hint from `setup_runevault_alias` to avoid duplication, but keeping both ensures visibility regardless of scroll position

## Test plan

- [x] Run `grep -rn 'role agent' install.sh scripts/install-dev.sh vault/vault_admin_cli.py` — no matches
- [x] Run `sudo bash install.sh` with local target — verify summary shows `--role member` and `exec $SHELL` hint
- [x] Run `sudo bash scripts/install-dev.sh` with local target — same verification