### PR TITLE
ci: add release workflow placeholder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,1 @@
+name: Release


### PR DESCRIPTION
## Context
Add an empty `release.yml` to register the workflow file in main so that `prereleased`/`released` triggers will be recognized by GitHub Actions.

## TL;DR
Placeholder `release.yml` to establish the workflow filename in the default branch.

## Summary
- Add `.github/workflows/release.yml` with a name-only stub

## Alternatives
- Ship the full workflow in one PR — deferred to keep this PR reviewable and unblock filename registration

## Test plan
- [x] Confirm `.github/workflows/release.yml` appears in main after merge