### PR TITLE
dev: remove worktree prefix on branch name rule for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ Follow `.github/PULL_REQUEST_TEMPLATE.md` exactly. Fill every section, replace a
 
 ## Development workflow
 
-- Feature branches: `worktree-issue-{N}-{description}`
+- Feature branches: `issue-{N}-{description}`
 - All changes via PR to main
 - Reference issue numbers in commits: `feat: description (#N)`
 - Rebase onto target branch, not merge commits in feature branches

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ Follow `.github/PULL_REQUEST_TEMPLATE.md` exactly. Fill every section, replace a
 
 ## Development workflow
 
-- Feature branches: `worktree-issue-{N}-{description}`
+- Feature branches: `issue-{N}-{description}`
 - All changes via PR to main
 - Reference issue numbers in commits: `feat: description (#N)`
 - Rebase onto target branch, not merge commits in feature branches


### PR DESCRIPTION
## Context
Agent branch naming convention used `worktree-issue-{N}-{description}` but this prefix was tied to the worktree workflow, which is no longer the default. Simplify to `issue-{N}-{description}`.

## TL;DR
Drop `worktree-` prefix from feature branch naming rule in CLAUDE.md and AGENTS.md.

## Summary
- Update `CLAUDE.md`: branch pattern `worktree-issue-{N}-...` → `issue-{N}-...`
- Update `AGENTS.md`: same change

## Alternatives
- Keep `worktree-` prefix — rejected because it implies worktree usage is required, which it is not

## Test plan
- [x] Confirm CLAUDE.md and AGENTS.md reflect `issue-{N}-{description}` pattern