### PR TITLE
chore: remove empty release.yml workflow placeholder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,1 +1,0 @@
-name: Release


### PR DESCRIPTION
## Context
`.github/workflows/release.yml` is an empty placeholder containing only `name: Release`. It registers a no-op workflow in Actions; the real release pipeline is `release.yaml`.

## TL;DR
Delete the empty release.yml placeholder; release.yaml is the real pipeline.

## Summary

- Remove `.github/workflows/release.yml` (only `name: Release`, no jobs)

## Alternatives

- Fill it in — rejected; `release.yaml` already implements the release pipeline

## Test plan

- [x] Confirmed file contained only `name: Release` with no jobs/triggers
- [x] Verified `release.yaml` remains the active release workflow