### PR TITLE
feat(vault): sole-client wiring for runespace — pre-encrypted forward, centroid relay, self-heal

### DIFF
--- a/vault/go.mod
+++ b/vault/go.mod
@@ -5,8 +5,8 @@ go 1.26.4
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1
 	buf.build/go/protovalidate v1.2.0
+	github.com/CryptoLabInc/runespace-sdk v0.1.3
 	github.com/google/uuid v1.6.0
-	github.com/CryptoLabInc/runespace-sdk v0.1.0
 	github.com/spf13/cobra v1.8.1
 	golang.org/x/crypto v0.47.0
 	google.golang.org/grpc v1.80.0
@@ -28,6 +28,3 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260120221211-b8f7ae30c516 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260120221211-b8f7ae30c516 // indirect
 )
-
-// Local runespace SDK (integration test) — replaces envector-go-sdk.
-replace github.com/CryptoLabInc/runespace-sdk => ../../runespace-sdk

--- a/vault/go.mod
+++ b/vault/go.mod
@@ -5,6 +5,7 @@ go 1.26.4
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260415201107-50325440f8f2.1
 	buf.build/go/protovalidate v1.2.0
+	github.com/google/uuid v1.6.0
 	github.com/CryptoLabInc/runespace-sdk v0.1.0
 	github.com/spf13/cobra v1.8.1
 	golang.org/x/crypto v0.47.0
@@ -18,7 +19,6 @@ require (
 	cel.dev/expr v0.25.1 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/google/cel-go v0.28.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/exp v0.0.0-20250813145105-42675adae3e6 // indirect

--- a/vault/go.mod
+++ b/vault/go.mod
@@ -28,3 +28,6 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20260120221211-b8f7ae30c516 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260120221211-b8f7ae30c516 // indirect
 )
+
+// Local runespace SDK (integration test) — replaces envector-go-sdk.
+replace github.com/CryptoLabInc/runespace-sdk => ../../runespace-sdk

--- a/vault/go.sum
+++ b/vault/go.sum
@@ -4,8 +4,8 @@ buf.build/go/protovalidate v1.2.0 h1:DQVrUWkmGTBij+kOYv/x2LLxwcLaGKMdzShj1/6/3H0
 buf.build/go/protovalidate v1.2.0/go.mod h1:7rYiQEhqvAipoazpVNBBH2S2f8bjG4huMVy1V2Yofn4=
 cel.dev/expr v0.25.1 h1:1KrZg61W6TWSxuNZ37Xy49ps13NUovb66QLprthtwi4=
 cel.dev/expr v0.25.1/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
-github.com/CryptoLabInc/runespace-sdk v0.1.0 h1:0TvUxqC0YZiFmLhUqw3dsEX0lTjSgRAQDWkSQdwK6yQ=
-github.com/CryptoLabInc/runespace-sdk v0.1.0/go.mod h1:7z/jS0mcQ0v2kKKEHsEh36PnsMr0TOEuska4vwj2jJ0=
+github.com/CryptoLabInc/runespace-sdk v0.1.3 h1:BLM/pCrDLewEAbVWngKXpcB4o2RHjpVSSh4gWiY7kys=
+github.com/CryptoLabInc/runespace-sdk v0.1.3/go.mod h1:63NTNvd8QnawsxJXCtcG6wkfKCARSqQpkyyuK7/LcU0=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/brianvoe/gofakeit/v6 v6.28.0 h1:Xib46XXuQfmlLS2EXRuJpqcw8St6qSZz75OUo0tgAW4=

--- a/vault/internal/crypto/keys.go
+++ b/vault/internal/crypto/keys.go
@@ -108,6 +108,43 @@ func OpenEngine(ctx context.Context, p EngineParams) (*Engine, error) {
 // Dim returns the FHE slot dimension the key set was opened with.
 func (e *Engine) Dim() int { return e.keys.Dim() }
 
+// ForwardInsert appends an item that rune-mcp already encrypted (EncKey) and
+// sealed (agent_dek), verbatim. The vault performs no crypto here — it is a
+// pure forward; idempotency rides on the client-generated it.ID.
+func (e *Engine) ForwardInsert(ctx context.Context, it runespace.PreEncryptedItem) error {
+	return e.client.InsertPreEncrypted(ctx, it)
+}
+
+// Centroids returns the engine's IVF centroid set for relay to rune-mcp
+// (and onward to runed). The SDK caches the fetch, so repeated relays cost
+// one stream total.
+func (e *Engine) Centroids(ctx context.Context) (*runespace.CentroidSet, error) {
+	return e.client.Centroids(ctx)
+}
+
+// encKeyFiles are the PUBLIC encryption-key artifacts GenerateKeys writes,
+// relative to the key directory. They are safe to hand to clients: EncKey
+// can only encrypt; decryption needs SecKey, which never leaves the vault.
+const (
+	rmpEncKeyFile = "EncKey.json"   // RMP envelope (JSON)
+	mmEncKeyFile  = "mm/EncKey.bin" // MM raw key bytes
+)
+
+// ReadEncKeys loads the two PUBLIC encryption keys for the agent manifest:
+// the RMP EncKey JSON envelope and the raw MM EncKey bytes.
+func ReadEncKeys(p KeysParams) (rmpJSON []byte, mmKey []byte, err error) {
+	dir := p.keyDir()
+	rmpJSON, err = os.ReadFile(filepath.Join(dir, rmpEncKeyFile))
+	if err != nil {
+		return nil, nil, fmt.Errorf("crypto: read %s: %w", rmpEncKeyFile, err)
+	}
+	mmKey, err = os.ReadFile(filepath.Join(dir, mmEncKeyFile))
+	if err != nil {
+		return nil, nil, fmt.Errorf("crypto: read %s: %w", mmEncKeyFile, err)
+	}
+	return rmpJSON, mmKey, nil
+}
+
 // Insert encrypts vec (EncKey, RMP+MM) and appends it under a fresh opaque id,
 // which it returns. sealedMeta is stored verbatim in the manifest — the caller
 // is responsible for sealing it (agent_dek) beforehand.

--- a/vault/internal/crypto/keys.go
+++ b/vault/internal/crypto/keys.go
@@ -111,8 +111,17 @@ func (e *Engine) Dim() int { return e.keys.Dim() }
 // ForwardInsert appends an item that rune-mcp already encrypted (EncKey) and
 // sealed (agent_dek), verbatim. The vault performs no crypto here — it is a
 // pure forward; idempotency rides on the client-generated it.ID.
+//
+// A centroid-version mismatch is the one error acted on locally: it proves the
+// engine replaced its set while our SDK cache (served to buildBundle and the
+// GetCentroids relay) still holds the old one, so the cache is dropped before
+// the error is relayed — the client's resync then receives the fresh set.
 func (e *Engine) ForwardInsert(ctx context.Context, it runespace.PreEncryptedItem) error {
-	return e.client.InsertPreEncrypted(ctx, it)
+	err := e.client.InsertPreEncrypted(ctx, it)
+	if errors.Is(err, runespace.ErrCentroidVersionMismatch) {
+		e.client.InvalidateCentroidCache()
+	}
+	return err
 }
 
 // Centroids returns the engine's IVF centroid set for relay to rune-mcp

--- a/vault/internal/server/grpc.go
+++ b/vault/internal/server/grpc.go
@@ -13,7 +13,7 @@ import (
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 
-	runespace "github.com/jh-lee-cryptolab/runespace-go-sdk"
+	runespace "github.com/CryptoLabInc/runespace-sdk"
 
 	"github.com/CryptoLabInc/rune-admin/vault/internal/crypto"
 	"github.com/CryptoLabInc/rune-admin/vault/internal/tokens"

--- a/vault/internal/server/grpc.go
+++ b/vault/internal/server/grpc.go
@@ -215,6 +215,14 @@ func (s *VaultGRPC) Insert(ctx context.Context, req *pb.InsertRequest) (*pb.Inse
 		statusStr = "error"
 		msg := err.Error()
 		errDetail = &msg
+		// §9.2 C3: the engine replaced its centroid set. The engine cache was
+		// already invalidated (ForwardInsert); relay a stable, typed signal so
+		// the client resyncs centroids and retries once with the same id. The
+		// WRONG_CENTROID_VERSION prefix is the wire contract rune-mcp matches.
+		if errors.Is(err, runespace.ErrCentroidVersionMismatch) {
+			wire := "WRONG_CENTROID_VERSION: centroid set was replaced; resync centroids and retry"
+			return &pb.InsertResponse{Error: wire}, status.Error(codes.FailedPrecondition, wire)
+		}
 		return &pb.InsertResponse{Error: msg}, status.Error(codes.Internal, msg)
 	}
 	resultCount = 1

--- a/vault/internal/server/grpc.go
+++ b/vault/internal/server/grpc.go
@@ -431,6 +431,7 @@ func (s *VaultGRPC) GetCentroids(req *pb.GetCentroidsRequest, stream pb.VaultSer
 		Version: cs.Version,
 		Dim:     uint32(cs.Dim),
 		Nlist:   uint32(len(cs.Vectors)),
+		Preset:  cs.Preset,
 	}}}); err != nil {
 		statusStr = "error"
 		msg := err.Error()

--- a/vault/internal/server/grpc.go
+++ b/vault/internal/server/grpc.go
@@ -2,13 +2,18 @@ package server
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"time"
+	"unicode/utf8"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
+
+	runespace "github.com/jh-lee-cryptolab/runespace-go-sdk"
 
 	"github.com/CryptoLabInc/rune-admin/vault/internal/crypto"
 	"github.com/CryptoLabInc/rune-admin/vault/internal/tokens"
@@ -107,13 +112,12 @@ func (s *VaultGRPC) GetAgentManifest(ctx context.Context, req *pb.GetAgentManife
 		return &pb.GetAgentManifestResponse{Error: err.Error()}, status.Error(codes.PermissionDenied, err.Error())
 	}
 
-	bundle := map[string]any{
-		"key_id":   s.v.bundleParams.KeyID,
-		"agent_id": crypto.AgentIDFromToken(req.GetToken()),
-		"dim":      s.v.cfg.Keys.EmbeddingDim,
-	}
-	if s.v.cfg.Keys.IndexName != "" {
-		bundle["index_name"] = s.v.cfg.Keys.IndexName
+	bundle, err := s.v.buildBundle(ctx, req.GetToken())
+	if err != nil {
+		statusStr = "error"
+		ed := err.Error()
+		errDetail = &ed
+		return &pb.GetAgentManifestResponse{Error: err.Error()}, status.Error(codes.Internal, err.Error())
 	}
 	js, err := json.Marshal(bundle)
 	if err != nil {
@@ -124,6 +128,44 @@ func (s *VaultGRPC) GetAgentManifest(ctx context.Context, req *pb.GetAgentManife
 	}
 	resultCount = 1
 	return &pb.GetAgentManifestResponse{ManifestJson: string(js)}, nil
+}
+
+// buildBundle assembles the agent manifest. The PUBLIC EncKey pair and the
+// caller's derived agent_dek leave the vault here — by design: capture-side
+// encryption/sealing happens on the developer machine. SecKey/EvalKey/
+// team_secret are never included.
+func (v *Vault) buildBundle(ctx context.Context, token string) (map[string]any, error) {
+	rmpJSON, mmKey, err := crypto.ReadEncKeys(v.bundleParams)
+	if err != nil {
+		return nil, err
+	}
+	agentID := crypto.AgentIDFromToken(token)
+	dek, err := crypto.DeriveAgentKey(v.cfg.Tokens.TeamSecret, agentID)
+	if err != nil {
+		return nil, err
+	}
+	bundle := map[string]any{
+		"EncKey.json": string(rmpJSON),
+		"mm_enc_key":  base64.StdEncoding.EncodeToString(mmKey),
+		"agent_id":    agentID,
+		"agent_dek":   base64.StdEncoding.EncodeToString(dek),
+		"key_id":      v.bundleParams.KeyID,
+		"dim":         v.cfg.Keys.EmbeddingDim,
+		// Capability flag: this vault expects client-encrypted inserts.
+		"insert": "pre_encrypted",
+	}
+	if v.cfg.Keys.IndexName != "" {
+		bundle["index_name"] = v.cfg.Keys.IndexName
+	}
+	// Current centroid set version so the client can judge cache freshness
+	// before pulling the (large) relay stream. Best-effort: an unreachable
+	// engine leaves it empty and the client retries via GetCentroids.
+	if v.engine != nil {
+		if cs, err := v.engine.Centroids(ctx); err == nil {
+			bundle["centroid_set_version"] = cs.Version
+		}
+	}
+	return bundle, nil
 }
 
 // ── Insert (capture write) ────────────────────────────────────────
@@ -161,23 +203,22 @@ func (s *VaultGRPC) Insert(ctx context.Context, req *pb.InsertRequest) (*pb.Inse
 		return &pb.InsertResponse{Error: msg}, status.Error(codes.Internal, msg)
 	}
 
-	sealed, err := s.sealMeta(req.GetToken(), req.GetMetadata())
-	if err != nil {
-		statusStr = "error"
-		msg := err.Error()
-		errDetail = &msg
-		return &pb.InsertResponse{Error: msg}, status.Error(codes.Internal, msg)
+	it := runespace.PreEncryptedItem{
+		ID:                 req.GetId(),
+		RMPBlob:            req.GetRmpItem(),
+		MMBlob:             req.GetMmItem(),
+		ClusterID:          req.GetClusterId(),
+		CentroidSetVersion: req.GetCentroidSetVersion(),
+		Metadata:           req.GetMetadata(),
 	}
-
-	id, err := s.v.engine.Insert(ctx, req.GetVector(), sealed)
-	if err != nil {
+	if err := s.v.engine.ForwardInsert(ctx, it); err != nil {
 		statusStr = "error"
 		msg := err.Error()
 		errDetail = &msg
 		return &pb.InsertResponse{Error: msg}, status.Error(codes.Internal, msg)
 	}
 	resultCount = 1
-	return &pb.InsertResponse{Id: id}, nil
+	return &pb.InsertResponse{Id: it.ID}, nil
 }
 
 // ── Search (recall + novelty) ─────────────────────────────────────
@@ -238,31 +279,6 @@ func (s *VaultGRPC) Search(ctx context.Context, req *pb.SearchRequest) (*pb.Sear
 	return &pb.SearchResponse{Hits: out}, nil
 }
 
-// sealMeta AES-seals plaintext metadata under the caller's per-agent DEK and
-// wraps it in an {a,c} envelope for storage. Empty metadata seals to "".
-func (s *VaultGRPC) sealMeta(token, meta string) (string, error) {
-	if meta == "" {
-		return "", nil
-	}
-	if s.v.cfg.Tokens.TeamSecret == "" {
-		return "", errors.New("VAULT_TEAM_SECRET not configured")
-	}
-	agentID := crypto.AgentIDFromToken(token)
-	dek, err := crypto.DeriveAgentKey(s.v.cfg.Tokens.TeamSecret, agentID)
-	if err != nil {
-		return "", err
-	}
-	c, err := crypto.EncryptMetadata([]byte(meta), dek)
-	if err != nil {
-		return "", err
-	}
-	b, err := json.Marshal(envelope{AgentID: agentID, Cipher: c})
-	if err != nil {
-		return "", err
-	}
-	return string(b), nil
-}
-
 // openMeta best-effort opens a sealed {a,c} envelope to plaintext JSON. On any
 // failure it returns the stored string unchanged (plaintext/legacy tolerated).
 func (s *VaultGRPC) openMeta(stored string) string {
@@ -279,6 +295,16 @@ func (s *VaultGRPC) openMeta(stored string) string {
 	}
 	pt, err := crypto.DecryptMetadata(env.Cipher, dek)
 	if err != nil {
+		return stored
+	}
+	// AES-CTR is unauthenticated: decrypting an envelope sealed under a
+	// different team_secret "succeeds" and yields garbage bytes. Invalid
+	// UTF-8 here would make the proto3 string unmarshalable and fail the
+	// whole Search response at the gRPC layer, so fall back to the sealed
+	// envelope instead. Proper fix is AEAD (AES-GCM) — see crypto/metadata.go.
+	if !utf8.Valid(pt) {
+		slog.Warn("vault: sealed metadata decrypted to non-UTF-8 bytes — returning envelope unopened (different team_secret or corrupted record)",
+			"agent_id", env.AgentID)
 		return stored
 	}
 	return string(pt)
@@ -341,4 +367,81 @@ func (s *VaultGRPC) emit(ctx context.Context, method, user string, topK *int32, 
 		LatencyMs:   float64(duration.Microseconds()) / 1000.0,
 		Error:       errDetail,
 	})
+}
+
+// ── GetCentroids (relay) ─────────────────────────────────────────
+
+// centroidBatchSize bounds one relay frame: 64 centroids × dim 1024 × 4B ≈
+// 256KB per message, comfortably under the gRPC frame cap.
+const centroidBatchSize = 64
+
+// GetCentroids relays the engine's IVF centroid set to rune-mcp so it can
+// push the set down to runed. Same wire shape as runespace's GetCentroids:
+// one header frame, then id-ordered batches.
+func (s *VaultGRPC) GetCentroids(req *pb.GetCentroidsRequest, stream pb.VaultService_GetCentroidsServer) error {
+	ctx := stream.Context()
+	start := time.Now()
+	user := s.v.tokens.GetUsername(req.GetToken())
+	if user == "" {
+		user = "unknown"
+	}
+	resultCount := 0
+	statusStr := "success"
+	var errDetail *string
+	defer func() {
+		s.emit(ctx, "get_centroids", user, nil, resultCount, statusStr, errDetail, time.Since(start))
+	}()
+
+	username, role, err := s.v.tokens.Validate(req.GetToken())
+	if err != nil {
+		st, msg := mapTokenError(err)
+		statusStr, errDetail = errStatus(err)
+		return status.Error(st, msg)
+	}
+	user = username
+	if err := role.CheckScope("get_public_key"); err != nil {
+		statusStr = "denied"
+		ed := err.Error()
+		errDetail = &ed
+		return status.Error(codes.PermissionDenied, err.Error())
+	}
+	if s.v.engine == nil {
+		statusStr = "error"
+		msg := "runespace engine not available"
+		errDetail = &msg
+		return status.Error(codes.Internal, msg)
+	}
+
+	cs, err := s.v.engine.Centroids(ctx)
+	if err != nil {
+		statusStr = "error"
+		msg := err.Error()
+		errDetail = &msg
+		return status.Error(codes.Internal, msg)
+	}
+	if err := stream.Send(&pb.CentroidChunk{Payload: &pb.CentroidChunk_Header{Header: &pb.CentroidSetHeader{
+		Version: cs.Version,
+		Dim:     uint32(cs.Dim),
+		Nlist:   uint32(len(cs.Vectors)),
+	}}}); err != nil {
+		statusStr = "error"
+		msg := err.Error()
+		errDetail = &msg
+		return err
+	}
+	for lo := 0; lo < len(cs.Vectors); lo += centroidBatchSize {
+		hi := min(lo+centroidBatchSize, len(cs.Vectors))
+		batch := make([]*pb.Centroid, 0, hi-lo)
+		for i := lo; i < hi; i++ {
+			batch = append(batch, &pb.Centroid{Id: uint32(i), Vec: cs.Vectors[i]})
+		}
+		if err := stream.Send(&pb.CentroidChunk{Payload: &pb.CentroidChunk_Batch{Batch: &pb.CentroidBatch{Centroids: batch}}}); err != nil {
+			statusStr = "error"
+			msg := err.Error()
+			errDetail = &msg
+			return err
+		}
+	}
+	resultCount = len(cs.Vectors)
+	return nil
 }

--- a/vault/internal/server/grpc_test.go
+++ b/vault/internal/server/grpc_test.go
@@ -65,9 +65,13 @@ func TestGetAgentManifestInvalidToken(t *testing.T) {
 func TestInsertInvalidToken(t *testing.T) {
 	srv := NewVaultGRPC(newTestVault(t))
 	_, err := srv.Insert(context.Background(), &pb.InsertRequest{
-		Token:    "evt_ffffffffffffffffffffffffffffffff",
-		Vector:   []float32{0.1, 0.2},
-		Metadata: `{"x":1}`,
+		Token:              "evt_ffffffffffffffffffffffffffffffff",
+		Id:                 "test-id-1",
+		RmpItem:            []byte{1},
+		MmItem:             []byte{2},
+		ClusterId:          0,
+		CentroidSetVersion: "v1",
+		Metadata:           `{"a":"x","c":"y"}`,
 	})
 	if status.Code(err) != codes.Unauthenticated {
 		t.Errorf("code = %v, want Unauthenticated", status.Code(err))

--- a/vault/internal/server/vault_l2_test.go
+++ b/vault/internal/server/vault_l2_test.go
@@ -16,7 +16,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	runespace "github.com/jh-lee-cryptolab/runespace-go-sdk"
+	runespace "github.com/CryptoLabInc/runespace-sdk"
 
 	"github.com/CryptoLabInc/rune-admin/vault/internal/crypto"
 	"github.com/CryptoLabInc/rune-admin/vault/internal/tokens"

--- a/vault/internal/server/vault_l2_test.go
+++ b/vault/internal/server/vault_l2_test.go
@@ -2,6 +2,9 @@ package server
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
 	"math"
 	"net"
 	"os"
@@ -9,19 +12,28 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+
+	runespace "github.com/jh-lee-cryptolab/runespace-go-sdk"
 
 	"github.com/CryptoLabInc/rune-admin/vault/internal/crypto"
 	"github.com/CryptoLabInc/rune-admin/vault/internal/tokens"
 	pb "github.com/CryptoLabInc/rune-admin/vault/pkg/vaultpb"
 )
 
-// TestVaultServiceL2 brings up the VaultService gRPC server in-process against a
-// LIVE runespace and exercises the mcp-facing contract end to end: token auth +
-// Insert (encrypt + seal metadata) + Search (decrypt + open metadata). Gated on
-// RUNESPACE_ADDR. Reuses the smoke-test key dir so it matches whatever eval key
-// runespace already has registered.
+// TestVaultServiceL2 brings up the VaultService gRPC server in-process against
+// a LIVE runespace and plays the rune-mcp role end to end under the
+// client-side-crypto contract:
+//
+//	GetAgentManifest → save EncKey pair → OpenKeys(Enc only)
+//	GetCentroids relay → assign cluster
+//	EncryptFlat/EncryptClustered + seal metadata (agent_dek)
+//	Insert (pre-encrypted forward) → Search → opened-metadata round trip
+//
+// Gated on RUNESPACE_ADDR. Reuses the smoke-test key dir so it matches
+// whatever eval key runespace already has registered.
 //
 //	RUNESPACE_ADDR=127.0.0.1:51024 go test ./internal/server -run VaultServiceL2 -v
 func TestVaultServiceL2(t *testing.T) {
@@ -31,12 +43,22 @@ func TestVaultServiceL2(t *testing.T) {
 	}
 	const dim = 1024
 
+	// The key set must be the one whose EvalKey the target runespace has
+	// registered — decrypting with a mismatched SecKey yields garbage scores.
+	// Point RUNESPACE_KEYS_ROOT/RUNESPACE_KEY_ID at that set; default is a
+	// throwaway smoke set (fresh engine only).
 	kp := crypto.KeysParams{Root: filepath.Join(os.TempDir(), "runespace-smoke"), KeyID: "smoke-key", Dim: dim}
+	if r := os.Getenv("RUNESPACE_KEYS_ROOT"); r != "" {
+		kp.Root = r
+	}
+	if id := os.Getenv("RUNESPACE_KEY_ID"); id != "" {
+		kp.KeyID = id
+	}
 	if err := crypto.EnsureKeys(kp); err != nil {
 		t.Fatalf("EnsureKeys: %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
 	eng, err := crypto.OpenEngine(ctx, crypto.EngineParams{Keys: kp, Endpoint: addr, Insecure: true})
@@ -53,6 +75,7 @@ func TestVaultServiceL2(t *testing.T) {
 	store.LoadDefaultsWithDemoToken()
 	audit, _ := NewAuditLogger(AuditConfig{Mode: ""})
 	v := NewVault(cfg, store, eng, audit)
+	v.bundleParams.KeyID = kp.KeyID // manifest must read the smoke key dir
 
 	// In-process gRPC server on a random port.
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
@@ -72,19 +95,142 @@ func TestVaultServiceL2(t *testing.T) {
 	defer conn.Close()
 	client := pb.NewVaultServiceClient(conn)
 
-	// A distinctive vector so the self-query is the clear top hit.
+	// ── mcp step 1: manifest → EncKey pair + agent_dek ──────────────
+	mf, err := client.GetAgentManifest(ctx, &pb.GetAgentManifestRequest{Token: tokens.DemoToken})
+	if err != nil {
+		t.Fatalf("GetAgentManifest RPC: %v", err)
+	}
+	var bundle struct {
+		EncKeyJSON string `json:"EncKey.json"`
+		MMEncKey   string `json:"mm_enc_key"`
+		AgentID    string `json:"agent_id"`
+		AgentDEK   string `json:"agent_dek"`
+		KeyID      string `json:"key_id"`
+		Dim        int    `json:"dim"`
+		Insert     string `json:"insert"`
+	}
+	if err := json.Unmarshal([]byte(mf.GetManifestJson()), &bundle); err != nil {
+		t.Fatalf("manifest parse: %v", err)
+	}
+	if bundle.Insert != "pre_encrypted" {
+		t.Fatalf("capability = %q, want pre_encrypted", bundle.Insert)
+	}
+	if bundle.EncKeyJSON == "" || bundle.MMEncKey == "" || bundle.AgentDEK == "" {
+		t.Fatal("manifest missing EncKey/mm_enc_key/agent_dek")
+	}
+	dek, err := base64.StdEncoding.DecodeString(bundle.AgentDEK)
+	if err != nil {
+		t.Fatalf("agent_dek decode: %v", err)
+	}
+	mmKey, err := base64.StdEncoding.DecodeString(bundle.MMEncKey)
+	if err != nil {
+		t.Fatalf("mm_enc_key decode: %v", err)
+	}
+
+	// ── mcp step 2: save keys in SDK layout, open Enc-only ──────────
+	clientKeyRoot := t.TempDir()
+	clientKeyDir := filepath.Join(clientKeyRoot, bundle.KeyID)
+	if err := os.MkdirAll(filepath.Join(clientKeyDir, "mm"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(clientKeyDir, "EncKey.json"), []byte(bundle.EncKeyJSON), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(clientKeyDir, "mm", "EncKey.bin"), mmKey, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	keys, err := runespace.OpenKeys(
+		runespace.WithKeyPath(clientKeyDir),
+		runespace.WithKeyID(bundle.KeyID),
+		runespace.WithKeyDim(bundle.Dim),
+		runespace.WithKeyParts(runespace.KeyPartEnc),
+	)
+	if err != nil {
+		t.Fatalf("client OpenKeys (Enc only): %v", err)
+	}
+	defer keys.Close()
+
+	// ── mcp step 3: centroid relay → cluster assignment ─────────────
+	cstream, err := client.GetCentroids(ctx, &pb.GetCentroidsRequest{Token: tokens.DemoToken})
+	if err != nil {
+		t.Fatalf("GetCentroids RPC: %v", err)
+	}
+	relay := &runespace.CentroidSet{}
+	for {
+		chunk, err := cstream.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("GetCentroids recv: %v", err)
+		}
+		switch p := chunk.GetPayload().(type) {
+		case *pb.CentroidChunk_Header:
+			relay.Version = p.Header.GetVersion()
+			relay.Dim = int(p.Header.GetDim())
+		case *pb.CentroidChunk_Batch:
+			for _, c := range p.Batch.GetCentroids() {
+				relay.Vectors = append(relay.Vectors, c.GetVec())
+			}
+		}
+	}
+	if !relay.Enabled() {
+		t.Fatal("centroid relay returned a disabled set")
+	}
+	t.Logf("centroid relay: version=%s nlist=%d", relay.Version, len(relay.Vectors))
+
+	// ── mcp step 4: encrypt + seal + forward ────────────────────────
+	// Unique per run: an identical vector from a previous run would tie at
+	// score 1.0 and steal the top slot from this run's insert.
+	phase := float64(time.Now().UnixNano()%100000) / 1000.0
 	vec := make([]float32, dim)
 	for i := range vec {
-		vec[i] = float32(math.Cos(float64(i)*0.013 + 0.5))
+		vec[i] = float32(math.Cos(float64(i)*0.013 + phase))
 	}
-	const meta = `{"title":"L2 vault test","n":7}`
+	var norm float64
+	for _, x := range vec {
+		norm += float64(x) * float64(x)
+	}
+	inv := float32(1 / math.Sqrt(norm))
+	for i := range vec {
+		vec[i] *= inv
+	}
 
-	ins, err := client.Insert(ctx, &pb.InsertRequest{Token: tokens.DemoToken, Vector: vec, Metadata: meta})
+	rmpBlob, err := keys.EncryptFlat(vec)
+	if err != nil {
+		t.Fatalf("EncryptFlat: %v", err)
+	}
+	mmBlob, err := keys.EncryptClustered(vec)
+	if err != nil {
+		t.Fatalf("EncryptClustered: %v", err)
+	}
+
+	const meta = `{"title":"L2 vault test","n":7}`
+	ct, err := crypto.EncryptMetadata([]byte(meta), dek)
+	if err != nil {
+		t.Fatalf("client seal: %v", err)
+	}
+	envJSON, _ := json.Marshal(envelope{AgentID: bundle.AgentID, Cipher: ct})
+
+	id := uuid.NewString()
+	ins, err := client.Insert(ctx, &pb.InsertRequest{
+		Token:              tokens.DemoToken,
+		Id:                 id,
+		RmpItem:            rmpBlob,
+		MmItem:             mmBlob,
+		ClusterId:          relay.Assign(vec),
+		CentroidSetVersion: relay.Version,
+		Metadata:           string(envJSON),
+	})
 	if err != nil {
 		t.Fatalf("Insert RPC: %v", err)
 	}
-	t.Logf("Insert ok id=%s", ins.GetId())
+	if ins.GetId() != id {
+		t.Fatalf("Insert echoed id %q, want %q", ins.GetId(), id)
+	}
+	t.Logf("Insert ok id=%s (client-encrypted forward)", ins.GetId())
 
+	// ── recall: vault decrypts scores + opens metadata ──────────────
 	sr, err := client.Search(ctx, &pb.SearchRequest{Token: tokens.DemoToken, Vector: vec, TopK: 5})
 	if err != nil {
 		t.Fatalf("Search RPC: %v", err)
@@ -100,11 +246,11 @@ func TestVaultServiceL2(t *testing.T) {
 	if top.GetScore() < 0.9 {
 		t.Fatalf("top score %.4f < 0.9", top.GetScore())
 	}
-	// The just-inserted item must come back with metadata SEALED then OPENED by
-	// the vault → we get the original plaintext JSON, proving the L2 seal/open path.
-	if top.GetId() != ins.GetId() {
-		t.Fatalf("top id %s != inserted %s", top.GetId(), ins.GetId())
+	if top.GetId() != id {
+		t.Fatalf("top id %s != inserted %s", top.GetId(), id)
 	}
+	// Client-sealed metadata must come back OPENED by the vault — proving the
+	// seal(client)/open(vault) split of the target architecture.
 	if top.GetMetadata() != meta {
 		t.Fatalf("metadata round-trip mismatch: got %q want %q", top.GetMetadata(), meta)
 	}

--- a/vault/pkg/vaultpb/vault_service.pb.go
+++ b/vault/pkg/vaultpb/vault_service.pb.go
@@ -69,7 +69,14 @@ func (x *GetAgentManifestRequest) GetToken() string {
 
 type GetAgentManifestResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// JSON: {"index_name": "...", "agent_id": "...", "dim": 1024} — no keys.
+	// JSON bundle:
+	//
+	//	"EncKey.json"          RMP EncKey envelope (public, for EncryptFlat)
+	//	"mm_enc_key"           base64(MM EncKey raw bytes, for EncryptClustered)
+	//	"agent_dek"            base64(caller's derived metadata DEK)
+	//	"key_id" "agent_id" "dim" "index_name"
+	//	"centroid_set_version" current engine set (empty = none loaded yet)
+	//	"insert"               capability flag: "pre_encrypted"
 	ManifestJson  string `protobuf:"bytes,1,opt,name=manifest_json,json=manifestJson,proto3" json:"manifest_json,omitempty"`
 	Error         string `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"` // Non-empty on error
 	unknownFields protoimpl.UnknownFields
@@ -124,12 +131,22 @@ type InsertRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Auth token. Required, fixed 36 chars.
 	Token string `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty"`
-	// Plaintext embedding (runed output). Length must equal the configured dim.
-	Vector []float32 `protobuf:"fixed32,2,rep,packed,name=vector,proto3" json:"vector,omitempty"`
-	// Plaintext metadata JSON. Vault seals it (agent_dek) before storing; may be empty.
-	Metadata      string `protobuf:"bytes,3,opt,name=metadata,proto3" json:"metadata,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// Sealed metadata envelope ({"a","c"}), client-sealed with agent_dek.
+	// Stored verbatim; the vault does not open or re-seal it on insert.
+	Metadata string `protobuf:"bytes,3,opt,name=metadata,proto3" json:"metadata,omitempty"`
+	// Client-generated opaque UUID. Required: retries at any hop reuse it so
+	// a re-insert is an idempotent no-op.
+	Id string `protobuf:"bytes,4,opt,name=id,proto3" json:"id,omitempty"`
+	// EncryptFlat output (flat tier ITEM encoding).
+	RmpItem []byte `protobuf:"bytes,5,opt,name=rmp_item,json=rmpItem,proto3" json:"rmp_item,omitempty"`
+	// EncryptClustered output (compact MM row).
+	MmItem []byte `protobuf:"bytes,6,opt,name=mm_item,json=mmItem,proto3" json:"mm_item,omitempty"`
+	// Plaintext IVF routing computed next to the embedding (runed).
+	ClusterId uint32 `protobuf:"varint,7,opt,name=cluster_id,json=clusterId,proto3" json:"cluster_id,omitempty"`
+	// Centroid set version the routing was computed against.
+	CentroidSetVersion string `protobuf:"bytes,8,opt,name=centroid_set_version,json=centroidSetVersion,proto3" json:"centroid_set_version,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *InsertRequest) Reset() {
@@ -169,13 +186,6 @@ func (x *InsertRequest) GetToken() string {
 	return ""
 }
 
-func (x *InsertRequest) GetVector() []float32 {
-	if x != nil {
-		return x.Vector
-	}
-	return nil
-}
-
 func (x *InsertRequest) GetMetadata() string {
 	if x != nil {
 		return x.Metadata
@@ -183,9 +193,44 @@ func (x *InsertRequest) GetMetadata() string {
 	return ""
 }
 
+func (x *InsertRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *InsertRequest) GetRmpItem() []byte {
+	if x != nil {
+		return x.RmpItem
+	}
+	return nil
+}
+
+func (x *InsertRequest) GetMmItem() []byte {
+	if x != nil {
+		return x.MmItem
+	}
+	return nil
+}
+
+func (x *InsertRequest) GetClusterId() uint32 {
+	if x != nil {
+		return x.ClusterId
+	}
+	return 0
+}
+
+func (x *InsertRequest) GetCentroidSetVersion() string {
+	if x != nil {
+		return x.CentroidSetVersion
+	}
+	return ""
+}
+
 type InsertResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`       // runespace-issued opaque id
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`       // echo of the client-supplied id on success
 	Error         string                 `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"` // Non-empty on error
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -410,6 +455,289 @@ func (x *SearchResponse) GetError() string {
 	return ""
 }
 
+type GetCentroidsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Auth token. Required, fixed 36 chars.
+	Token         string `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetCentroidsRequest) Reset() {
+	*x = GetCentroidsRequest{}
+	mi := &file_vault_service_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetCentroidsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetCentroidsRequest) ProtoMessage() {}
+
+func (x *GetCentroidsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_vault_service_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetCentroidsRequest.ProtoReflect.Descriptor instead.
+func (*GetCentroidsRequest) Descriptor() ([]byte, []int) {
+	return file_vault_service_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *GetCentroidsRequest) GetToken() string {
+	if x != nil {
+		return x.Token
+	}
+	return ""
+}
+
+type CentroidChunk struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Payload:
+	//
+	//	*CentroidChunk_Header
+	//	*CentroidChunk_Batch
+	Payload       isCentroidChunk_Payload `protobuf_oneof:"payload"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CentroidChunk) Reset() {
+	*x = CentroidChunk{}
+	mi := &file_vault_service_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CentroidChunk) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CentroidChunk) ProtoMessage() {}
+
+func (x *CentroidChunk) ProtoReflect() protoreflect.Message {
+	mi := &file_vault_service_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CentroidChunk.ProtoReflect.Descriptor instead.
+func (*CentroidChunk) Descriptor() ([]byte, []int) {
+	return file_vault_service_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *CentroidChunk) GetPayload() isCentroidChunk_Payload {
+	if x != nil {
+		return x.Payload
+	}
+	return nil
+}
+
+func (x *CentroidChunk) GetHeader() *CentroidSetHeader {
+	if x != nil {
+		if x, ok := x.Payload.(*CentroidChunk_Header); ok {
+			return x.Header
+		}
+	}
+	return nil
+}
+
+func (x *CentroidChunk) GetBatch() *CentroidBatch {
+	if x != nil {
+		if x, ok := x.Payload.(*CentroidChunk_Batch); ok {
+			return x.Batch
+		}
+	}
+	return nil
+}
+
+type isCentroidChunk_Payload interface {
+	isCentroidChunk_Payload()
+}
+
+type CentroidChunk_Header struct {
+	Header *CentroidSetHeader `protobuf:"bytes,1,opt,name=header,proto3,oneof"`
+}
+
+type CentroidChunk_Batch struct {
+	Batch *CentroidBatch `protobuf:"bytes,2,opt,name=batch,proto3,oneof"`
+}
+
+func (*CentroidChunk_Header) isCentroidChunk_Payload() {}
+
+func (*CentroidChunk_Batch) isCentroidChunk_Payload() {}
+
+type CentroidSetHeader struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Version       string                 `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"` // content hash (sha256)
+	Dim           uint32                 `protobuf:"varint,2,opt,name=dim,proto3" json:"dim,omitempty"`
+	Nlist         uint32                 `protobuf:"varint,3,opt,name=nlist,proto3" json:"nlist,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CentroidSetHeader) Reset() {
+	*x = CentroidSetHeader{}
+	mi := &file_vault_service_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CentroidSetHeader) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CentroidSetHeader) ProtoMessage() {}
+
+func (x *CentroidSetHeader) ProtoReflect() protoreflect.Message {
+	mi := &file_vault_service_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CentroidSetHeader.ProtoReflect.Descriptor instead.
+func (*CentroidSetHeader) Descriptor() ([]byte, []int) {
+	return file_vault_service_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *CentroidSetHeader) GetVersion() string {
+	if x != nil {
+		return x.Version
+	}
+	return ""
+}
+
+func (x *CentroidSetHeader) GetDim() uint32 {
+	if x != nil {
+		return x.Dim
+	}
+	return 0
+}
+
+func (x *CentroidSetHeader) GetNlist() uint32 {
+	if x != nil {
+		return x.Nlist
+	}
+	return 0
+}
+
+type CentroidBatch struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Centroids     []*Centroid            `protobuf:"bytes,1,rep,name=centroids,proto3" json:"centroids,omitempty"` // id order (append order == cluster id)
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CentroidBatch) Reset() {
+	*x = CentroidBatch{}
+	mi := &file_vault_service_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CentroidBatch) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CentroidBatch) ProtoMessage() {}
+
+func (x *CentroidBatch) ProtoReflect() protoreflect.Message {
+	mi := &file_vault_service_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CentroidBatch.ProtoReflect.Descriptor instead.
+func (*CentroidBatch) Descriptor() ([]byte, []int) {
+	return file_vault_service_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *CentroidBatch) GetCentroids() []*Centroid {
+	if x != nil {
+		return x.Centroids
+	}
+	return nil
+}
+
+type Centroid struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            uint32                 `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
+	Vec           []float32              `protobuf:"fixed32,2,rep,packed,name=vec,proto3" json:"vec,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Centroid) Reset() {
+	*x = Centroid{}
+	mi := &file_vault_service_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Centroid) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Centroid) ProtoMessage() {}
+
+func (x *Centroid) ProtoReflect() protoreflect.Message {
+	mi := &file_vault_service_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Centroid.ProtoReflect.Descriptor instead.
+func (*Centroid) Descriptor() ([]byte, []int) {
+	return file_vault_service_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *Centroid) GetId() uint32 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *Centroid) GetVec() []float32 {
+	if x != nil {
+		return x.Vec
+	}
+	return nil
+}
+
 var File_vault_service_proto protoreflect.FileDescriptor
 
 const file_vault_service_proto_rawDesc = "" +
@@ -419,11 +747,16 @@ const file_vault_service_proto_rawDesc = "" +
 	"\x05token\x18\x01 \x01(\tB\t\xbaH\x06r\x04\x10$\x18$R\x05token\"U\n" +
 	"\x18GetAgentManifestResponse\x12#\n" +
 	"\rmanifest_json\x18\x01 \x01(\tR\fmanifestJson\x12\x14\n" +
-	"\x05error\x18\x02 \x01(\tR\x05error\"n\n" +
+	"\x05error\x18\x02 \x01(\tR\x05error\"\x95\x02\n" +
 	"\rInsertRequest\x12\x1f\n" +
-	"\x05token\x18\x01 \x01(\tB\t\xbaH\x06r\x04\x10$\x18$R\x05token\x12 \n" +
-	"\x06vector\x18\x02 \x03(\x02B\b\xbaH\x05\x92\x01\x02\b\x01R\x06vector\x12\x1a\n" +
-	"\bmetadata\x18\x03 \x01(\tR\bmetadata\"6\n" +
+	"\x05token\x18\x01 \x01(\tB\t\xbaH\x06r\x04\x10$\x18$R\x05token\x12\x1a\n" +
+	"\bmetadata\x18\x03 \x01(\tR\bmetadata\x12\x19\n" +
+	"\x02id\x18\x04 \x01(\tB\t\xbaH\x06r\x04\x10\x01\x18@R\x02id\x12\"\n" +
+	"\brmp_item\x18\x05 \x01(\fB\a\xbaH\x04z\x02\x10\x01R\armpItem\x12 \n" +
+	"\amm_item\x18\x06 \x01(\fB\a\xbaH\x04z\x02\x10\x01R\x06mmItem\x12\x1d\n" +
+	"\n" +
+	"cluster_id\x18\a \x01(\rR\tclusterId\x129\n" +
+	"\x14centroid_set_version\x18\b \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x12centroidSetVersionJ\x04\b\x02\x10\x03R\x06vector\"6\n" +
 	"\x0eInsertResponse\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x14\n" +
 	"\x05error\x18\x02 \x01(\tR\x05error\"s\n" +
@@ -438,11 +771,27 @@ const file_vault_service_proto_rawDesc = "" +
 	"\bmetadata\x18\x03 \x01(\tR\bmetadata\"T\n" +
 	"\x0eSearchResponse\x12,\n" +
 	"\x04hits\x18\x01 \x03(\v2\x18.rune.vault.v1.SearchHitR\x04hits\x12\x14\n" +
-	"\x05error\x18\x02 \x01(\tR\x05error2\x81\x02\n" +
+	"\x05error\x18\x02 \x01(\tR\x05error\"6\n" +
+	"\x13GetCentroidsRequest\x12\x1f\n" +
+	"\x05token\x18\x01 \x01(\tB\t\xbaH\x06r\x04\x10$\x18$R\x05token\"\x8c\x01\n" +
+	"\rCentroidChunk\x12:\n" +
+	"\x06header\x18\x01 \x01(\v2 .rune.vault.v1.CentroidSetHeaderH\x00R\x06header\x124\n" +
+	"\x05batch\x18\x02 \x01(\v2\x1c.rune.vault.v1.CentroidBatchH\x00R\x05batchB\t\n" +
+	"\apayload\"U\n" +
+	"\x11CentroidSetHeader\x12\x18\n" +
+	"\aversion\x18\x01 \x01(\tR\aversion\x12\x10\n" +
+	"\x03dim\x18\x02 \x01(\rR\x03dim\x12\x14\n" +
+	"\x05nlist\x18\x03 \x01(\rR\x05nlist\"F\n" +
+	"\rCentroidBatch\x125\n" +
+	"\tcentroids\x18\x01 \x03(\v2\x17.rune.vault.v1.CentroidR\tcentroids\"0\n" +
+	"\bCentroid\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\rR\x02id\x12\x14\n" +
+	"\x03vec\x18\x02 \x03(\x02B\x02\x10\x01R\x03vec2\xd5\x02\n" +
 	"\fVaultService\x12c\n" +
 	"\x10GetAgentManifest\x12&.rune.vault.v1.GetAgentManifestRequest\x1a'.rune.vault.v1.GetAgentManifestResponse\x12E\n" +
 	"\x06Insert\x12\x1c.rune.vault.v1.InsertRequest\x1a\x1d.rune.vault.v1.InsertResponse\x12E\n" +
-	"\x06Search\x12\x1c.rune.vault.v1.SearchRequest\x1a\x1d.rune.vault.v1.SearchResponseb\x06proto3"
+	"\x06Search\x12\x1c.rune.vault.v1.SearchRequest\x1a\x1d.rune.vault.v1.SearchResponse\x12R\n" +
+	"\fGetCentroids\x12\".rune.vault.v1.GetCentroidsRequest\x1a\x1c.rune.vault.v1.CentroidChunk0\x01b\x06proto3"
 
 var (
 	file_vault_service_proto_rawDescOnce sync.Once
@@ -456,7 +805,7 @@ func file_vault_service_proto_rawDescGZIP() []byte {
 	return file_vault_service_proto_rawDescData
 }
 
-var file_vault_service_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_vault_service_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_vault_service_proto_goTypes = []any{
 	(*GetAgentManifestRequest)(nil),  // 0: rune.vault.v1.GetAgentManifestRequest
 	(*GetAgentManifestResponse)(nil), // 1: rune.vault.v1.GetAgentManifestResponse
@@ -465,20 +814,30 @@ var file_vault_service_proto_goTypes = []any{
 	(*SearchRequest)(nil),            // 4: rune.vault.v1.SearchRequest
 	(*SearchHit)(nil),                // 5: rune.vault.v1.SearchHit
 	(*SearchResponse)(nil),           // 6: rune.vault.v1.SearchResponse
+	(*GetCentroidsRequest)(nil),      // 7: rune.vault.v1.GetCentroidsRequest
+	(*CentroidChunk)(nil),            // 8: rune.vault.v1.CentroidChunk
+	(*CentroidSetHeader)(nil),        // 9: rune.vault.v1.CentroidSetHeader
+	(*CentroidBatch)(nil),            // 10: rune.vault.v1.CentroidBatch
+	(*Centroid)(nil),                 // 11: rune.vault.v1.Centroid
 }
 var file_vault_service_proto_depIdxs = []int32{
-	5, // 0: rune.vault.v1.SearchResponse.hits:type_name -> rune.vault.v1.SearchHit
-	0, // 1: rune.vault.v1.VaultService.GetAgentManifest:input_type -> rune.vault.v1.GetAgentManifestRequest
-	2, // 2: rune.vault.v1.VaultService.Insert:input_type -> rune.vault.v1.InsertRequest
-	4, // 3: rune.vault.v1.VaultService.Search:input_type -> rune.vault.v1.SearchRequest
-	1, // 4: rune.vault.v1.VaultService.GetAgentManifest:output_type -> rune.vault.v1.GetAgentManifestResponse
-	3, // 5: rune.vault.v1.VaultService.Insert:output_type -> rune.vault.v1.InsertResponse
-	6, // 6: rune.vault.v1.VaultService.Search:output_type -> rune.vault.v1.SearchResponse
-	4, // [4:7] is the sub-list for method output_type
-	1, // [1:4] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	5,  // 0: rune.vault.v1.SearchResponse.hits:type_name -> rune.vault.v1.SearchHit
+	9,  // 1: rune.vault.v1.CentroidChunk.header:type_name -> rune.vault.v1.CentroidSetHeader
+	10, // 2: rune.vault.v1.CentroidChunk.batch:type_name -> rune.vault.v1.CentroidBatch
+	11, // 3: rune.vault.v1.CentroidBatch.centroids:type_name -> rune.vault.v1.Centroid
+	0,  // 4: rune.vault.v1.VaultService.GetAgentManifest:input_type -> rune.vault.v1.GetAgentManifestRequest
+	2,  // 5: rune.vault.v1.VaultService.Insert:input_type -> rune.vault.v1.InsertRequest
+	4,  // 6: rune.vault.v1.VaultService.Search:input_type -> rune.vault.v1.SearchRequest
+	7,  // 7: rune.vault.v1.VaultService.GetCentroids:input_type -> rune.vault.v1.GetCentroidsRequest
+	1,  // 8: rune.vault.v1.VaultService.GetAgentManifest:output_type -> rune.vault.v1.GetAgentManifestResponse
+	3,  // 9: rune.vault.v1.VaultService.Insert:output_type -> rune.vault.v1.InsertResponse
+	6,  // 10: rune.vault.v1.VaultService.Search:output_type -> rune.vault.v1.SearchResponse
+	8,  // 11: rune.vault.v1.VaultService.GetCentroids:output_type -> rune.vault.v1.CentroidChunk
+	8,  // [8:12] is the sub-list for method output_type
+	4,  // [4:8] is the sub-list for method input_type
+	4,  // [4:4] is the sub-list for extension type_name
+	4,  // [4:4] is the sub-list for extension extendee
+	0,  // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_vault_service_proto_init() }
@@ -486,13 +845,17 @@ func file_vault_service_proto_init() {
 	if File_vault_service_proto != nil {
 		return
 	}
+	file_vault_service_proto_msgTypes[8].OneofWrappers = []any{
+		(*CentroidChunk_Header)(nil),
+		(*CentroidChunk_Batch)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_vault_service_proto_rawDesc), len(file_vault_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   7,
+			NumMessages:   12,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/vault/pkg/vaultpb/vault_service.pb.go
+++ b/vault/pkg/vaultpb/vault_service.pb.go
@@ -583,10 +583,14 @@ func (*CentroidChunk_Header) isCentroidChunk_Payload() {}
 func (*CentroidChunk_Batch) isCentroidChunk_Payload() {}
 
 type CentroidSetHeader struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Version       string                 `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"` // content hash (sha256)
-	Dim           uint32                 `protobuf:"varint,2,opt,name=dim,proto3" json:"dim,omitempty"`
-	Nlist         uint32                 `protobuf:"varint,3,opt,name=nlist,proto3" json:"nlist,omitempty"`
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	Version string                 `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"` // content hash (sha256)
+	Dim     uint32                 `protobuf:"varint,2,opt,name=dim,proto3" json:"dim,omitempty"`
+	Nlist   uint32                 `protobuf:"varint,3,opt,name=nlist,proto3" json:"nlist,omitempty"`
+	// evi preset the set was trained for (e.g. "IP1") — a version-hash
+	// ingredient, relayed so runed can recompute and verify the content hash.
+	// Empty when the engine predates the field.
+	Preset        string `protobuf:"bytes,4,opt,name=preset,proto3" json:"preset,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -640,6 +644,13 @@ func (x *CentroidSetHeader) GetNlist() uint32 {
 		return x.Nlist
 	}
 	return 0
+}
+
+func (x *CentroidSetHeader) GetPreset() string {
+	if x != nil {
+		return x.Preset
+	}
+	return ""
 }
 
 type CentroidBatch struct {
@@ -777,11 +788,12 @@ const file_vault_service_proto_rawDesc = "" +
 	"\rCentroidChunk\x12:\n" +
 	"\x06header\x18\x01 \x01(\v2 .rune.vault.v1.CentroidSetHeaderH\x00R\x06header\x124\n" +
 	"\x05batch\x18\x02 \x01(\v2\x1c.rune.vault.v1.CentroidBatchH\x00R\x05batchB\t\n" +
-	"\apayload\"U\n" +
+	"\apayload\"m\n" +
 	"\x11CentroidSetHeader\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12\x10\n" +
 	"\x03dim\x18\x02 \x01(\rR\x03dim\x12\x14\n" +
-	"\x05nlist\x18\x03 \x01(\rR\x05nlist\"F\n" +
+	"\x05nlist\x18\x03 \x01(\rR\x05nlist\x12\x16\n" +
+	"\x06preset\x18\x04 \x01(\tR\x06preset\"F\n" +
 	"\rCentroidBatch\x125\n" +
 	"\tcentroids\x18\x01 \x03(\v2\x17.rune.vault.v1.CentroidR\tcentroids\"0\n" +
 	"\bCentroid\x12\x0e\n" +

--- a/vault/pkg/vaultpb/vault_service_grpc.pb.go
+++ b/vault/pkg/vaultpb/vault_service_grpc.pb.go
@@ -22,6 +22,7 @@ const (
 	VaultService_GetAgentManifest_FullMethodName = "/rune.vault.v1.VaultService/GetAgentManifest"
 	VaultService_Insert_FullMethodName           = "/rune.vault.v1.VaultService/Insert"
 	VaultService_Search_FullMethodName           = "/rune.vault.v1.VaultService/Search"
+	VaultService_GetCentroids_FullMethodName     = "/rune.vault.v1.VaultService/GetCentroids"
 )
 
 // VaultServiceClient is the client API for VaultService service.
@@ -29,21 +30,29 @@ const (
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://pkg.go.dev/google.golang.org/grpc/?tab=doc#ClientConn.NewStream.
 //
 // Rune-Vault gRPC service.
-// Holds ALL FHE keys (Enc/Eval/Sec) + agent_dek, performs every
-// encryption/decryption, and is the SOLE runespace client. rune-mcp is a
-// pure-Go client that talks only to this service; it never touches runespace
-// or the FHE SDK directly.
+// The vault generates and custodies the FHE key set. The PUBLIC EncKey and
+// the caller's derived agent_dek are handed to rune-mcp via GetAgentManifest
+// so capture encryption/sealing happens on the developer machine; SecKey,
+// EvalKey, and team_secret never leave this server. The vault is the SOLE
+// runespace client — rune-mcp talks only to this service and forwards
+// ciphertext through it.
 type VaultServiceClient interface {
-	// Returns the agent manifest (config only — no FHE keys ever leave the vault).
+	// Returns the agent manifest: EncKey (RMP+MM, public), the caller's
+	// agent_dek, index config, centroid_set_version, and capability flags.
 	GetAgentManifest(ctx context.Context, in *GetAgentManifestRequest, opts ...grpc.CallOption) (*GetAgentManifestResponse, error)
-	// Capture write: encrypt a plaintext embedding (EncKey) + seal metadata
-	// (agent_dek), then insert into runespace via the SDK.
+	// Capture write: forward a client-encrypted item (EncryptFlat +
+	// EncryptClustered blobs, plaintext cluster routing, sealed metadata)
+	// verbatim to runespace. The vault sees no plaintext content.
 	Insert(ctx context.Context, in *InsertRequest, opts ...grpc.CallOption) (*InsertResponse, error)
 	// Blind vector search over runespace (recall + capture-time novelty check).
 	// The plaintext query is sent to runespace (PCMM); the vault decrypts the
 	// score blobs (SecKey), ranks, resolves and opens metadata (agent_dek), and
 	// returns ranked plaintext hits.
 	Search(ctx context.Context, in *SearchRequest, opts ...grpc.CallOption) (*SearchResponse, error)
+	// Relays the runespace IVF centroid set (header, then id-ordered batches)
+	// so rune-mcp can push it down to runed for insert routing. Public
+	// structural data — same wire shape as runespace's GetCentroids.
+	GetCentroids(ctx context.Context, in *GetCentroidsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[CentroidChunk], error)
 }
 
 type vaultServiceClient struct {
@@ -84,26 +93,53 @@ func (c *vaultServiceClient) Search(ctx context.Context, in *SearchRequest, opts
 	return out, nil
 }
 
+func (c *vaultServiceClient) GetCentroids(ctx context.Context, in *GetCentroidsRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[CentroidChunk], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &VaultService_ServiceDesc.Streams[0], VaultService_GetCentroids_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[GetCentroidsRequest, CentroidChunk]{ClientStream: stream}
+	if err := x.ClientStream.SendMsg(in); err != nil {
+		return nil, err
+	}
+	if err := x.ClientStream.CloseSend(); err != nil {
+		return nil, err
+	}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type VaultService_GetCentroidsClient = grpc.ServerStreamingClient[CentroidChunk]
+
 // VaultServiceServer is the server API for VaultService service.
 // All implementations must embed UnimplementedVaultServiceServer
 // for forward compatibility.
 //
 // Rune-Vault gRPC service.
-// Holds ALL FHE keys (Enc/Eval/Sec) + agent_dek, performs every
-// encryption/decryption, and is the SOLE runespace client. rune-mcp is a
-// pure-Go client that talks only to this service; it never touches runespace
-// or the FHE SDK directly.
+// The vault generates and custodies the FHE key set. The PUBLIC EncKey and
+// the caller's derived agent_dek are handed to rune-mcp via GetAgentManifest
+// so capture encryption/sealing happens on the developer machine; SecKey,
+// EvalKey, and team_secret never leave this server. The vault is the SOLE
+// runespace client — rune-mcp talks only to this service and forwards
+// ciphertext through it.
 type VaultServiceServer interface {
-	// Returns the agent manifest (config only — no FHE keys ever leave the vault).
+	// Returns the agent manifest: EncKey (RMP+MM, public), the caller's
+	// agent_dek, index config, centroid_set_version, and capability flags.
 	GetAgentManifest(context.Context, *GetAgentManifestRequest) (*GetAgentManifestResponse, error)
-	// Capture write: encrypt a plaintext embedding (EncKey) + seal metadata
-	// (agent_dek), then insert into runespace via the SDK.
+	// Capture write: forward a client-encrypted item (EncryptFlat +
+	// EncryptClustered blobs, plaintext cluster routing, sealed metadata)
+	// verbatim to runespace. The vault sees no plaintext content.
 	Insert(context.Context, *InsertRequest) (*InsertResponse, error)
 	// Blind vector search over runespace (recall + capture-time novelty check).
 	// The plaintext query is sent to runespace (PCMM); the vault decrypts the
 	// score blobs (SecKey), ranks, resolves and opens metadata (agent_dek), and
 	// returns ranked plaintext hits.
 	Search(context.Context, *SearchRequest) (*SearchResponse, error)
+	// Relays the runespace IVF centroid set (header, then id-ordered batches)
+	// so rune-mcp can push it down to runed for insert routing. Public
+	// structural data — same wire shape as runespace's GetCentroids.
+	GetCentroids(*GetCentroidsRequest, grpc.ServerStreamingServer[CentroidChunk]) error
 	mustEmbedUnimplementedVaultServiceServer()
 }
 
@@ -122,6 +158,9 @@ func (UnimplementedVaultServiceServer) Insert(context.Context, *InsertRequest) (
 }
 func (UnimplementedVaultServiceServer) Search(context.Context, *SearchRequest) (*SearchResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Search not implemented")
+}
+func (UnimplementedVaultServiceServer) GetCentroids(*GetCentroidsRequest, grpc.ServerStreamingServer[CentroidChunk]) error {
+	return status.Error(codes.Unimplemented, "method GetCentroids not implemented")
 }
 func (UnimplementedVaultServiceServer) mustEmbedUnimplementedVaultServiceServer() {}
 func (UnimplementedVaultServiceServer) testEmbeddedByValue()                      {}
@@ -198,6 +237,17 @@ func _VaultService_Search_Handler(srv interface{}, ctx context.Context, dec func
 	return interceptor(ctx, in, info, handler)
 }
 
+func _VaultService_GetCentroids_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(GetCentroidsRequest)
+	if err := stream.RecvMsg(m); err != nil {
+		return err
+	}
+	return srv.(VaultServiceServer).GetCentroids(m, &grpc.GenericServerStream[GetCentroidsRequest, CentroidChunk]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type VaultService_GetCentroidsServer = grpc.ServerStreamingServer[CentroidChunk]
+
 // VaultService_ServiceDesc is the grpc.ServiceDesc for VaultService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -218,6 +268,12 @@ var VaultService_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _VaultService_Search_Handler,
 		},
 	},
-	Streams:  []grpc.StreamDesc{},
+	Streams: []grpc.StreamDesc{
+		{
+			StreamName:    "GetCentroids",
+			Handler:       _VaultService_GetCentroids_Handler,
+			ServerStreams: true,
+		},
+	},
 	Metadata: "vault_service.proto",
 }

--- a/vault/proto/vault_service.proto
+++ b/vault/proto/vault_service.proto
@@ -123,6 +123,10 @@ message CentroidSetHeader {
   string version = 1; // content hash (sha256)
   uint32 dim = 2;
   uint32 nlist = 3;
+  // evi preset the set was trained for (e.g. "IP1") — a version-hash
+  // ingredient, relayed so runed can recompute and verify the content hash.
+  // Empty when the engine predates the field.
+  string preset = 4;
 }
 
 message CentroidBatch {

--- a/vault/proto/vault_service.proto
+++ b/vault/proto/vault_service.proto
@@ -5,16 +5,20 @@ package rune.vault.v1;
 import "buf/validate/validate.proto";
 
 // Rune-Vault gRPC service.
-// Holds ALL FHE keys (Enc/Eval/Sec) + agent_dek, performs every
-// encryption/decryption, and is the SOLE runespace client. rune-mcp is a
-// pure-Go client that talks only to this service; it never touches runespace
-// or the FHE SDK directly.
+// The vault generates and custodies the FHE key set. The PUBLIC EncKey and
+// the caller's derived agent_dek are handed to rune-mcp via GetAgentManifest
+// so capture encryption/sealing happens on the developer machine; SecKey,
+// EvalKey, and team_secret never leave this server. The vault is the SOLE
+// runespace client — rune-mcp talks only to this service and forwards
+// ciphertext through it.
 service VaultService {
-  // Returns the agent manifest (config only — no FHE keys ever leave the vault).
+  // Returns the agent manifest: EncKey (RMP+MM, public), the caller's
+  // agent_dek, index config, centroid_set_version, and capability flags.
   rpc GetAgentManifest(GetAgentManifestRequest) returns (GetAgentManifestResponse);
 
-  // Capture write: encrypt a plaintext embedding (EncKey) + seal metadata
-  // (agent_dek), then insert into runespace via the SDK.
+  // Capture write: forward a client-encrypted item (EncryptFlat +
+  // EncryptClustered blobs, plaintext cluster routing, sealed metadata)
+  // verbatim to runespace. The vault sees no plaintext content.
   rpc Insert(InsertRequest) returns (InsertResponse);
 
   // Blind vector search over runespace (recall + capture-time novelty check).
@@ -22,6 +26,11 @@ service VaultService {
   // score blobs (SecKey), ranks, resolves and opens metadata (agent_dek), and
   // returns ranked plaintext hits.
   rpc Search(SearchRequest) returns (SearchResponse);
+
+  // Relays the runespace IVF centroid set (header, then id-ordered batches)
+  // so rune-mcp can push it down to runed for insert routing. Public
+  // structural data — same wire shape as runespace's GetCentroids.
+  rpc GetCentroids(GetCentroidsRequest) returns (stream CentroidChunk);
 }
 
 // ─── GetAgentManifest ─────────────────────────────────────────────
@@ -32,7 +41,13 @@ message GetAgentManifestRequest {
 }
 
 message GetAgentManifestResponse {
-  // JSON: {"index_name": "...", "agent_id": "...", "dim": 1024} — no keys.
+  // JSON bundle:
+  //   "EncKey.json"          RMP EncKey envelope (public, for EncryptFlat)
+  //   "mm_enc_key"           base64(MM EncKey raw bytes, for EncryptClustered)
+  //   "agent_dek"            base64(caller's derived metadata DEK)
+  //   "key_id" "agent_id" "dim" "index_name"
+  //   "centroid_set_version" current engine set (empty = none loaded yet)
+  //   "insert"               capability flag: "pre_encrypted"
   string manifest_json = 1;
   string error = 2;  // Non-empty on error
 }
@@ -42,14 +57,28 @@ message GetAgentManifestResponse {
 message InsertRequest {
   // Auth token. Required, fixed 36 chars.
   string token = 1 [(buf.validate.field).string = {min_len: 36, max_len: 36}];
-  // Plaintext embedding (runed output). Length must equal the configured dim.
-  repeated float vector = 2 [(buf.validate.field).repeated.min_items = 1];
-  // Plaintext metadata JSON. Vault seals it (agent_dek) before storing; may be empty.
+  // Field 2 was the plaintext embedding of the integration experiment.
+  // The vault never receives plaintext content anymore.
+  reserved 2;
+  reserved "vector";
+  // Sealed metadata envelope ({"a","c"}), client-sealed with agent_dek.
+  // Stored verbatim; the vault does not open or re-seal it on insert.
   string metadata = 3;
+  // Client-generated opaque UUID. Required: retries at any hop reuse it so
+  // a re-insert is an idempotent no-op.
+  string id = 4 [(buf.validate.field).string = {min_len: 1, max_len: 64}];
+  // EncryptFlat output (flat tier ITEM encoding).
+  bytes rmp_item = 5 [(buf.validate.field).bytes.min_len = 1];
+  // EncryptClustered output (compact MM row).
+  bytes mm_item = 6 [(buf.validate.field).bytes.min_len = 1];
+  // Plaintext IVF routing computed next to the embedding (runed).
+  uint32 cluster_id = 7;
+  // Centroid set version the routing was computed against.
+  string centroid_set_version = 8 [(buf.validate.field).string.min_len = 1];
 }
 
 message InsertResponse {
-  string id = 1;     // runespace-issued opaque id
+  string id = 1;     // echo of the client-supplied id on success
   string error = 2;  // Non-empty on error
 }
 
@@ -73,4 +102,34 @@ message SearchHit {
 message SearchResponse {
   repeated SearchHit hits = 1;  // ranked, score descending
   string error = 2;             // Non-empty on error
+}
+
+
+// ─── GetCentroids (relay) ─────────────────────────────────────────
+
+message GetCentroidsRequest {
+  // Auth token. Required, fixed 36 chars.
+  string token = 1 [(buf.validate.field).string = {min_len: 36, max_len: 36}];
+}
+
+message CentroidChunk {
+  oneof payload {
+    CentroidSetHeader header = 1;
+    CentroidBatch batch = 2;
+  }
+}
+
+message CentroidSetHeader {
+  string version = 1; // content hash (sha256)
+  uint32 dim = 2;
+  uint32 nlist = 3;
+}
+
+message CentroidBatch {
+  repeated Centroid centroids = 1; // id order (append order == cluster id)
+}
+
+message Centroid {
+  uint32 id = 1;
+  repeated float vec = 2 [packed = true];
 }


### PR DESCRIPTION
## 요약
vault를 runespace의 **유일한 클라이언트**로 만드는 배선 + centroid 자가치유 + 릴레이 무결성(preset) + 공개 SDK 리포 전환.

- proto: InsertRequest의 평문 vector 필드 제거(reserved), 암호문 필드(rmp/mm/cluster_id/centroid_set_version) 추가, `GetCentroids` 스트림 RPC 신설
- `buildBundle` 확장 — EncKey + `mm_enc_key` + `agent_dek` + `centroid_set_version` + capability `insert:"pre_encrypted"` 배포 (클라이언트 측 암호화 모델)
- Insert 핸들러 = `ForwardInsert` (암호문 무검증 전달, 봉인은 클라이언트 몫)
- 자가치유: version mismatch 목격 시 SDK centroid 캐시 무효화 + `WRONG_CENTROID_VERSION`(FailedPrecondition) 중계
- 릴레이 헤더에 `preset = 4` 추가 — runed가 centroid content-hash를 재검산할 수 있게 (sha 재검산)
- SDK 의존을 공개 리포 `CryptoLabInc/runespace-sdk`로 전환

첫 커밋(b3c95f5)은 평문 수신 실험이었고 be65951이 뒤집었습니다 — 최종 상태는 pre-encrypted forward 모델입니다.

## 검증
- 단위 + L2 테스트 green
- 실스택 E2E: 12포인트(activate/boot/capture/recall/batch/reload/재기동) + wire 불변식 8종(tap 실측 — Insert에 평문 벡터 부재 등)

## 참고
- runespace-sdk PR과 함께 리뷰 권장 (이 PR이 그 SDK를 사용).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
