### PR TITLE
fix(updater): handle systemd cross-mount publishing

### DIFF
--- a/deployment/systemd/runeconsole.service
+++ b/deployment/systemd/runeconsole.service
@@ -21,7 +21,8 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=true
-ReadWritePaths=/opt/runeconsole /var/lib/runeconsole-updater/inbox /var/lib/runeconsole-updater/staging
+# Keep staging and inbox on one sandbox mount: request publication uses link(2).
+ReadWritePaths=/opt/runeconsole /var/lib/runeconsole-updater
 ProtectKernelTunables=true
 ProtectKernelModules=true
 ProtectControlGroups=true

--- a/install.sh
+++ b/install.sh
@@ -1274,7 +1274,8 @@ install_service() {
       "PrivateTmp=true" \
       "ProtectSystem=strict" \
       "ProtectHome=true" \
-      "ReadWritePaths=${INSTALL_PREFIX} ${UPDATE_INBOX_DIR} ${UPDATE_STAGING_DIR}" \
+      "# Keep staging and inbox on one sandbox mount: request publication uses link(2)." \
+      "ReadWritePaths=${INSTALL_PREFIX} ${UPDATE_STATE_DIR}" \
       "ProtectKernelTunables=true" \
       "ProtectKernelModules=true" \
       "ProtectControlGroups=true" \

--- a/internal/updater/systemd_unit_test.go
+++ b/internal/updater/systemd_unit_test.go
@@ -1,0 +1,48 @@
+package updater
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRuneconsoleSystemdSandboxKeepsUpdateHandoffOnOneMount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		path          string
+		wantMount     string
+		separateMount string
+	}{
+		{
+			name:          "checked-in unit",
+			path:          filepath.Join("..", "..", "deployment", "systemd", "runeconsole.service"),
+			wantMount:     "ReadWritePaths=/opt/runeconsole /var/lib/runeconsole-updater",
+			separateMount: "ReadWritePaths=/opt/runeconsole /var/lib/runeconsole-updater/inbox /var/lib/runeconsole-updater/staging",
+		},
+		{
+			name:          "installer-generated unit",
+			path:          filepath.Join("..", "..", "install.sh"),
+			wantMount:     `"ReadWritePaths=${INSTALL_PREFIX} ${UPDATE_STATE_DIR}"`,
+			separateMount: `"ReadWritePaths=${INSTALL_PREFIX} ${UPDATE_INBOX_DIR} ${UPDATE_STAGING_DIR}"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			body, err := os.ReadFile(test.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			unit := string(body)
+			if strings.Contains(unit, test.separateMount) {
+				t.Fatalf("%s gives inbox and staging separate systemd bind mounts; link(2) cannot publish the staged request across them", test.path)
+			}
+			if !strings.Contains(unit, test.wantMount) {
+				t.Fatalf("%s does not expose the shared updater root as one writable systemd mount", test.path)
+			}
+		})
+	}
+}

--- a/internal/updater/webupdate.go
+++ b/internal/updater/webupdate.go
@@ -431,6 +431,14 @@ func newUpdateJobID() (string, error) {
 }
 
 func enqueueUpdateRequest(stagingDir, requestPath string, request UpdateJobRequest) error {
+	return enqueueUpdateRequestWithLink(stagingDir, requestPath, request, os.Link)
+}
+
+func enqueueUpdateRequestWithLink(
+	stagingDir, requestPath string,
+	request UpdateJobRequest,
+	link func(string, string) error,
+) error {
 	if err := validateUpdateJobRequest(request); err != nil {
 		return err
 	}
@@ -447,10 +455,47 @@ func enqueueUpdateRequest(stagingDir, requestPath string, request UpdateJobReque
 	if err != nil {
 		return err
 	}
-	tempPath := filepath.Join(resolvedStaging, ".request-"+request.JobID)
+	tempPath, err := stageUpdateRequest(resolvedStaging, request.JobID, body)
+	if err != nil {
+		return err
+	}
+	defer removeStagedUpdateRequest(tempPath)
+
+	// A hard link is the publish point: the watcher sees either no request or
+	// the complete, fsynced JSON inode. Unlike Rename, Link cannot overwrite a
+	// request another browser/session already queued.
+	linkErr := link(tempPath, resolvedRequest)
+	if errors.Is(linkErr, syscall.EXDEV) {
+		// Older systemd units exposed staging and inbox as separate
+		// ReadWritePaths. systemd turns each path into its own bind mount, so
+		// link(2) reports EXDEV even when both directories are on the same
+		// filesystem. Restage inside the already-validated inbox and retain the
+		// same atomic, no-overwrite hard-link publication semantics.
+		inboxTempPath, fallbackErr := stageUpdateRequest(filepath.Dir(resolvedRequest), request.JobID, body)
+		if fallbackErr != nil {
+			return fallbackErr
+		}
+		defer removeStagedUpdateRequest(inboxTempPath)
+		linkErr = link(inboxTempPath, resolvedRequest)
+	}
+	if linkErr != nil {
+		if errors.Is(linkErr, fs.ErrExist) || errors.Is(linkErr, syscall.EEXIST) {
+			return ErrUpdateInProgress
+		}
+		return fmt.Errorf("publish update request: %w", linkErr)
+	}
+	if err := syncDirectory(filepath.Dir(resolvedRequest)); err != nil {
+		_ = os.Remove(resolvedRequest)
+		return errors.New("persist update request directory failed")
+	}
+	return nil
+}
+
+func stageUpdateRequest(directory, jobID string, body []byte) (string, error) {
+	tempPath := filepath.Join(directory, ".request-"+jobID)
 	fd, err := syscall.Open(tempPath, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_EXCL|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0o600)
 	if err != nil {
-		return fmt.Errorf("stage update request: %w", err)
+		return "", fmt.Errorf("stage update request: %w", err)
 	}
 	f := os.NewFile(uintptr(fd), "runeconsole-update-request")
 	_, writeErr := f.Write(body)
@@ -458,26 +503,14 @@ func enqueueUpdateRequest(stagingDir, requestPath string, request UpdateJobReque
 	closeErr := f.Close()
 	if err := errors.Join(writeErr, syncErr, closeErr); err != nil {
 		_ = os.Remove(tempPath)
-		return errors.New("persist update request failed")
+		return "", errors.New("persist update request failed")
 	}
-	defer func() {
-		_ = os.Remove(tempPath)
-		_ = syncDirectory(resolvedStaging)
-	}()
-	// A hard link is the publish point: the watcher sees either no request or
-	// the complete, fsynced JSON inode. Unlike Rename, Link cannot overwrite a
-	// request another browser/session already queued.
-	if err := os.Link(tempPath, resolvedRequest); err != nil {
-		if errors.Is(err, fs.ErrExist) || errors.Is(err, syscall.EEXIST) {
-			return ErrUpdateInProgress
-		}
-		return fmt.Errorf("publish update request: %w", err)
-	}
-	if err := syncDirectory(filepath.Dir(resolvedRequest)); err != nil {
-		_ = os.Remove(resolvedRequest)
-		return errors.New("persist update request directory failed")
-	}
-	return nil
+	return tempPath, nil
+}
+
+func removeStagedUpdateRequest(path string) {
+	_ = os.Remove(path)
+	_ = syncDirectory(filepath.Dir(path))
 }
 
 func peekUpdateRequest(path string) (UpdateJobRequest, error) {

--- a/internal/updater/webupdate_test.go
+++ b/internal/updater/webupdate_test.go
@@ -416,6 +416,32 @@ func TestUpdateRequestAndStatusFilesAreStrictAndAtomic(t *testing.T) {
 			t.Fatalf("staging leaked %d files", len(entries))
 		}
 	})
+	t.Run("cross-mount staging falls back to the inbox", func(t *testing.T) {
+		env := newWebControlTestEnv(t, true)
+		request := UpdateJobRequest{JobID: "abcdefghijklmnop", TargetVersion: "v1.1.0", RequestedAt: time.Now().UTC()}
+		linkCalls := 0
+		link := func(oldPath, newPath string) error {
+			linkCalls++
+			if linkCalls == 1 {
+				return syscall.EXDEV
+			}
+			return os.Link(oldPath, newPath)
+		}
+		if err := enqueueUpdateRequestWithLink(env.paths.Staging, env.paths.Request, request, link); err != nil {
+			t.Fatalf("enqueue across sandbox mounts: %v", err)
+		}
+		if linkCalls != 2 {
+			t.Fatalf("link calls = %d, want primary attempt plus inbox fallback", linkCalls)
+		}
+		entries, err := os.ReadDir(env.paths.Staging)
+		if err != nil || len(entries) != 0 {
+			t.Fatalf("staging entries after fallback = %v, %v", entries, err)
+		}
+		got, err := ConsumeUpdateRequest(env.paths.Request)
+		if err != nil || got.JobID != request.JobID {
+			t.Fatalf("consume fallback request = %+v, %v", got, err)
+		}
+	})
 	t.Run("strict request JSON", func(t *testing.T) {
 		env := newWebControlTestEnv(t, true)
 		body := `{"jobId":"abcdefghijklmnop","targetVersion":"v1.1.0","requestedAt":"2026-07-20T00:00:00Z","binaryPath":"/tmp/evil"}`


### PR DESCRIPTION
### Context
Linux 설치 설정에서 요청을 준비하는 staging과 updater가 감시하는 inbox를 systemd에 각각 별도의 쓰기 경로로 등록

### Problem
완성된 요청을 staging에서 inbox로 원자적으로 연결하려 했고, 운영체제는 이를 서로 다른 파일시스템 간 작업으로 판단 -> 오류 반환

### Solution
신규 설치에서는 staging과 inbox의 공통 상위 디렉터리를 systemd에 하나의 쓰기 경로로 등록