### PR TITLE
Release v1.0.2: console API username contract fix, workspace reconnect, installer/updater fixes

### DIFF
--- a/deployment/systemd/runeconsole.service
+++ b/deployment/systemd/runeconsole.service
@@ -21,7 +21,8 @@ NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=true
-ReadWritePaths=/opt/runeconsole /var/lib/runeconsole-updater/inbox /var/lib/runeconsole-updater/staging
+# Keep staging and inbox on one sandbox mount: request publication uses link(2).
+ReadWritePaths=/opt/runeconsole /var/lib/runeconsole-updater
 ProtectKernelTunables=true
 ProtectKernelModules=true
 ProtectControlGroups=true

--- a/frontend/mock-server/routes/update.ts
+++ b/frontend/mock-server/routes/update.ts
@@ -1,0 +1,39 @@
+// System-update endpoints (owner-facing): read update availability/state and
+// queue an update to a server-selected release. Mirrors the backend contract
+// (GET → UpdateStatus, POST {version} → 202 {state,version}) so the SC update
+// card has an intended-contract reference against the mock.
+import { HttpError, sendJson } from "../http.ts";
+import type { Ctx } from "../router.ts";
+import { state } from "../store.ts";
+
+export const getSystemUpdate = (ctx: Ctx): void => {
+  sendJson(ctx.res, 200, state.systemUpdate);
+};
+
+export const postSystemUpdate = (ctx: Ctx): void => {
+  const body = (ctx.body ?? {}) as { version?: unknown };
+  const version = typeof body.version === "string" ? body.version.trim() : "";
+  if (version === "") {
+    throw new HttpError(400, "UPDATE_REQUEST_INVALID", "version is required");
+  }
+  if (!state.systemUpdate.updateAvailable) {
+    throw new HttpError(
+      409,
+      "UPDATE_NOT_AVAILABLE",
+      "the requested update is no longer available",
+    );
+  }
+  if (
+    state.systemUpdate.state === "queued" ||
+    state.systemUpdate.state === "running"
+  ) {
+    throw new HttpError(
+      409,
+      "UPDATE_ALREADY_PENDING",
+      "an update is already pending",
+    );
+  }
+  state.systemUpdate.state = "queued";
+  state.systemUpdate.targetVersion = version;
+  sendJson(ctx.res, 202, { state: "queued", version });
+};

--- a/frontend/mock-server/server.ts
+++ b/frontend/mock-server/server.ts
@@ -14,6 +14,7 @@ import * as memberships from "./routes/memberships.ts";
 import * as mock from "./routes/mockControl.ts";
 import * as teamMembers from "./routes/teamMembers.ts";
 import * as teams from "./routes/teams.ts";
+import * as update from "./routes/update.ts";
 import * as users from "./routes/users.ts";
 import * as workspace from "./routes/workspace.ts";
 import { getSession, touchSession } from "./store.ts";
@@ -82,6 +83,10 @@ router.post("/api/v1/invitations", invitations.invite);
 router.post("/api/v1/invitations/resend", invitations.resend);
 router.post("/api/v1/invitations/cancel", invitations.cancel);
 router.get("/api/v1/invitations", invitations.invitationHistory);
+
+// ---- System update ---------------------------------------------------------
+router.get("/api/v1/system/update", update.getSystemUpdate);
+router.post("/api/v1/system/update", update.postSystemUpdate);
 
 const applyCors = (req: IncomingMessage, res: ServerResponse): void => {
   const origin = req.headers.origin;

--- a/frontend/mock-server/store.ts
+++ b/frontend/mock-server/store.ts
@@ -7,6 +7,7 @@ import type {
   InvitationRow,
   Membership,
   Session,
+  SystemUpdate,
   Team,
   User,
   Workspace,
@@ -23,6 +24,7 @@ export type State = {
   // set via POST /__mock/workspace/fail so the frontend can reproduce the
   // SC-02 failure screens (D-1 실패 / D-2 / D-3 / D-4).
   workspaceFail: Map<string, { status: number; code: string }>;
+  systemUpdate: SystemUpdate;
   session: Session;
   // Pending OAuth `state` values issued by /console/auth/start, consumed once
   // by /auth/callback.
@@ -174,6 +176,15 @@ const buildState = (): State => {
       orphaned: false,
     },
     workspaceFail: new Map(),
+    // Seeded with an available update so the SC update card renders against the
+    // mock; POST /system/update flips this to "queued".
+    systemUpdate: {
+      currentVersion: "1.0.0",
+      targetVersion: "1.0.1",
+      updateAvailable: true,
+      capable: true,
+      state: "idle",
+    },
     session: freshSession(),
     pendingAuthStates: new Set<string>(),
     seq: 100,

--- a/frontend/mock-server/types.ts
+++ b/frontend/mock-server/types.ts
@@ -76,3 +76,21 @@ export type Session = {
   plan: string;
   me: Principal | null;
 };
+
+export type SystemUpdateState =
+  | "idle"
+  | "queued"
+  | "running"
+  | "failed"
+  | "succeeded";
+
+// Owner-facing update view (GET /api/v1/system/update). Mirrors the backend
+// UpdateStatus: updateAvailable = targetVersion strictly newer; capable = the
+// privileged helper is installed.
+export type SystemUpdate = {
+  currentVersion: string;
+  targetVersion?: string;
+  updateAvailable: boolean;
+  capable: boolean;
+  state: SystemUpdateState;
+};

--- a/frontend/src/components/navigation/Navbar.tsx
+++ b/frontend/src/components/navigation/Navbar.tsx
@@ -73,6 +73,13 @@ const Navbar = () => {
                 <span className="border-negative text-negative rounded border px-2 py-1 text-xs">
                   재생성 필요
                 </span>
+              ) : workspace.reconnectRequired ? (
+                /* Data-plane credential expired: the cloud workspace is fine but
+                   the local engine link is stale. Flag it (not the healthy pill);
+                   clicking opens the modal's 재연결 prompt. */
+                <span className="border-warning text-warning rounded border px-2 py-1 text-xs">
+                  재연결 필요
+                </span>
               ) : (
                 <WorkspaceStatus status={workspace.status} />
               )

--- a/frontend/src/components/workspace/WorkspaceModal.tsx
+++ b/frontend/src/components/workspace/WorkspaceModal.tsx
@@ -6,6 +6,7 @@ import TextButton from "@/components/elements/TextButton";
 import WorkspaceStatus from "@/components/elements/WorkspaceStatus";
 import ModalLayout from "@/components/layout/ModalLayout";
 import {
+  useCreateWorkspaceMutation,
   useDeleteWorkspaceMutation,
   useRecreateWorkspaceMutation,
   useStartWorkspaceMutation,
@@ -66,6 +67,9 @@ const WorkspaceModal = () => {
   const startMutation = useStartWorkspaceMutation();
   const deleteMutation = useDeleteWorkspaceMutation();
   const recreateMutation = useRecreateWorkspaceMutation();
+  // POST /workspace re-bootstraps the expired data-plane credential — the same
+  // connect endpoint the empty-state create uses.
+  const reconnectMutation = useCreateWorkspaceMutation();
 
   const status = workspace?.status ?? "error";
   /* Transitional phases (+ any request in flight) lock the actions. */
@@ -185,6 +189,44 @@ const WorkspaceModal = () => {
                   navigate(PATH_LIST.workspace);
                 },
               })
+            }
+          />
+        </div>
+      </ModalLayout>
+    );
+  }
+
+  /* Reconnect — the data-plane credential expired. The cloud workspace is
+     healthy; POST /workspace re-bootstraps the local engine link. Takes
+     precedence over the detail body (the workspace can't serve until the link
+     is restored) and is mutually exclusive with orphaned — the backend returns
+     the orphaned flag first, so both are never set at once. */
+  if (workspace?.reconnectRequired) {
+    return (
+      <ModalLayout title={MODAL_TITLES.workspaceReconnect} isOpen>
+        <p className="text-center text-base">
+          워크스페이스 연결이 만료되었습니다.
+          <br />
+          재연결하여 데이터 플레인을 다시 활성화해 주세요.
+        </p>
+        {reconnectMutation.isError && (
+          <Notice tone="error">재연결에 실패했습니다. 다시 시도해 주세요.</Notice>
+        )}
+        <div className="flex w-full gap-2">
+          <Button
+            btnText={BTN_TEXT.close}
+            btnSize="md"
+            btnColor="grayOutline"
+            disabled={reconnectMutation.isPending}
+            handleClick={closeModal}
+          />
+          <Button
+            btnText={BTN_TEXT.reconnect}
+            btnSize="md"
+            btnColor="mintFilled"
+            disabled={reconnectMutation.isPending}
+            handleClick={() =>
+              reconnectMutation.mutate(undefined, { onSuccess: closeModal })
             }
           />
         </div>

--- a/frontend/src/components/workspace/__tests__/WorkspaceModal.test.tsx
+++ b/frontend/src/components/workspace/__tests__/WorkspaceModal.test.tsx
@@ -44,6 +44,7 @@ const RUNNING: TWorkspace = {
   endpoint: "https://a1b2c3d4.rune.example.com",
   rowCount: 431,
   orphaned: false,
+  reconnectRequired: false,
 };
 
 const setStatus = (status: TWorkspaceStatus) => {

--- a/frontend/src/constants/commonConstants.ts
+++ b/frontend/src/constants/commonConstants.ts
@@ -36,6 +36,7 @@ export const BTN_TEXT = {
   stop: "중지",
   deactivate: "비활성화",
   recreate: "삭제 후 재생성",
+  reconnect: "재연결",
   // Teams
   createTeam: "새 팀 만들기",
   createGroup: "팀 생성하기",
@@ -67,6 +68,7 @@ export const MODAL_TITLES = {
   workspaceManage: "워크스페이스 관리",
   workspaceDelete: "워크스페이스 삭제",
   workspaceOrphaned: "워크스페이스 재생성 필요",
+  workspaceReconnect: "워크스페이스 재연결 필요",
   // Teams
   createTeam: "새 팀 만들기",
   renameTeam: "팀 이름 변경",

--- a/frontend/src/hooks/queries/useWorkspaceQuery.ts
+++ b/frontend/src/hooks/queries/useWorkspaceQuery.ts
@@ -38,6 +38,7 @@ export const useWorkspaceQuery = () =>
         endpoint: data.endpointUrl,
         rowCount: data.rows,
         orphaned: data.orphaned ?? false,
+        reconnectRequired: data.reconnect ?? false,
       };
     },
     refetchInterval: (query) => {

--- a/frontend/src/types/commonTypes.ts
+++ b/frontend/src/types/commonTypes.ts
@@ -46,6 +46,13 @@ export type TWorkspace = {
    * deleted + recreated. Absent/false on a healthy workspace.
    */
   orphaned: boolean;
+  /**
+   * The data-plane credential expired and a background reconnect cannot
+   * re-bootstrap it — the user must drive a reconnect (POST /workspace). The
+   * cloud workspace itself is healthy; only the local engine link is stale.
+   * Mutually exclusive with orphaned (recreate supersedes reconnect).
+   */
+  reconnectRequired: boolean;
 };
 
 /** Wire shape of `GET /workspace` (console API design 2026-07-13, §Workspace). */
@@ -55,6 +62,8 @@ export type TWorkspaceWire = {
   rows: number | null;
   /** true when the workspace no longer matches this console (reinstall). */
   orphaned?: boolean;
+  /** true when the data-plane credential expired and needs a user-driven reconnect. */
+  reconnect?: boolean;
 };
 
 /** Recursive team-tree node (UIKIT AdminTeamNode, wireframe SC-06). */

--- a/install.sh
+++ b/install.sh
@@ -539,19 +539,14 @@ open_console_tunnel() {
   fi
 }
 
-# install_connect_shortcut writes a `runeconsole connect` command into the
-# invoking user's shell rc (zsh → .zshrc, bash → .bashrc, else .profile) so the
-# loopback console tunnel can be reopened later without retyping the ssh command.
-# Idempotent: a marker-delimited block is rewritten in place on re-install (so a
-# changed IP / key path propagates). If a real `runeconsole` binary is already on
-# PATH the shortcut is skipped so it is never shadowed.
-install_connect_shortcut() {
-  local key_path=$1 public_ip=$2
+# _login_rc_file echoes the shell rc file for the invoking user's login shell
+# (zsh → .zshrc, bash → .bashrc, else .profile). Detection works under sudo:
+# passwd on Linux, dscl on macOS, $SHELL as a last resort. Shared by the
+# connect-shortcut install (CSP) and removal (local) paths.
+_login_rc_file() {
   local login_user="${SUDO_USER:-$(id -un)}"
   local user_home; user_home=$(eval echo "~${login_user}")
 
-  # Detect the login shell (works under sudo): passwd on Linux, dscl on macOS,
-  # $SHELL as a last resort — then map it to the rc file we append to.
   local login_shell=""
   if command -v getent >/dev/null 2>&1; then
     login_shell=$(getent passwd "$login_user" 2>/dev/null | cut -d: -f7)
@@ -561,12 +556,38 @@ install_connect_shortcut() {
   fi
   [[ -z "$login_shell" ]] && login_shell="${SHELL:-}"
 
-  local rc_file
   case "$login_shell" in
-    *zsh)  rc_file="${user_home}/.zshrc" ;;
-    *bash) rc_file="${user_home}/.bashrc" ;;
-    *)     rc_file="${user_home}/.profile" ;;
+    *zsh)  printf '%s/.zshrc\n'   "$user_home" ;;
+    *bash) printf '%s/.bashrc\n'  "$user_home" ;;
+    *)     printf '%s/.profile\n' "$user_home" ;;
   esac
+}
+
+# remove_connect_shortcut strips the marker-delimited `runeconsole connect`
+# tunnel shim from the invoking user's shell rc. The shim is a CSP-only helper;
+# on a local install a real `runeconsole` binary lands on PATH and a leftover
+# shell function from an earlier CSP install would shadow it, so the local path
+# always clears it. No-op when the block is absent.
+remove_connect_shortcut() {
+  local rc_file; rc_file=$(_login_rc_file)
+  local begin="# >>> runeconsole connect >>>"
+  [[ -f "$rc_file" ]] && grep -qF "$begin" "$rc_file" || return 0
+
+  local tmp; tmp=$(mktemp)
+  sed "/# >>> runeconsole connect >>>/,/# <<< runeconsole connect <<</d" "$rc_file" > "$tmp" && mv "$tmp" "$rc_file"
+  [[ -n "${SUDO_USER:-}" ]] && chown "${SUDO_USER}" "$rc_file" 2>/dev/null || true
+  info "Removed the CSP 'runeconsole connect' tunnel shim from ${rc_file} (a local install needs no tunnel)."
+}
+
+# install_connect_shortcut writes a `runeconsole connect` command into the
+# invoking user's shell rc (zsh → .zshrc, bash → .bashrc, else .profile) so the
+# loopback console tunnel can be reopened later without retyping the ssh command.
+# Idempotent: a marker-delimited block is rewritten in place on re-install (so a
+# changed IP / key path propagates). If a real `runeconsole` binary is already on
+# PATH the shortcut is skipped so it is never shadowed.
+install_connect_shortcut() {
+  local key_path=$1 public_ip=$2
+  local rc_file; rc_file=$(_login_rc_file)
 
   # Never shadow an existing runeconsole command on PATH.
   if command -v runeconsole >/dev/null 2>&1; then
@@ -1477,6 +1498,11 @@ install_service() {
 
 # ── Phase 8: Post-install summary ─────────────────────────────────────────────
 post_install() {
+  # A local install serves the console directly at 127.0.0.1:8787 and needs no
+  # tunnel. Clear any `runeconsole connect` shim an earlier CSP install left in
+  # the shell rc so it can't shadow the real runeconsole binary now on PATH.
+  remove_connect_shortcut
+
   if [[ "$SKIP_SERVICE" -eq 0 ]]; then
     info "Waiting for the daemon to start (first boot generates FHE keys — this can take a minute)..."
     local i console_up=0

--- a/install.sh
+++ b/install.sh
@@ -1295,7 +1295,8 @@ install_service() {
       "PrivateTmp=true" \
       "ProtectSystem=strict" \
       "ProtectHome=true" \
-      "ReadWritePaths=${INSTALL_PREFIX} ${UPDATE_INBOX_DIR} ${UPDATE_STAGING_DIR}" \
+      "# Keep staging and inbox on one sandbox mount: request publication uses link(2)." \
+      "ReadWritePaths=${INSTALL_PREFIX} ${UPDATE_STATE_DIR}" \
       "ProtectKernelTunables=true" \
       "ProtectKernelModules=true" \
       "ProtectControlGroups=true" \

--- a/internal/console/workspace.go
+++ b/internal/console/workspace.go
@@ -87,12 +87,17 @@ func (s *Service) handleWorkspaceStatus(w http.ResponseWriter, r *http.Request) 
 		// The cloud rejected the data-plane refresh credential and background
 		// reconnects have no session to re-bootstrap with — retrying is
 		// pointless until the SPA drives a reconnect (POST /api/v1/workspace).
-		// Doc contract: 502 CLOUD_AUTH_EXPIRED on this polled endpoint is what
-		// feeds the SC-03 navbar badge. (Ordered after the nil check: a deleted
-		// workspace's 404 route-guard signal outranks a stale credential badge.
-		// Not logged here — the SPA polls this every few seconds and the 401
-		// that raised the flag is already logged once at its source.)
-		writeError(w, http.StatusBadGateway, "CLOUD_AUTH_EXPIRED", "cloud credential expired; reconnect the workspace")
+		// Surface it as a `reconnect` flag on the 200 view (the same shape as
+		// orphaned), not a 502: erroring this polled endpoint blanks the SC-03
+		// navbar badge and kills the SPA's poll loop, leaving no reconnect
+		// affordance. The SPA renders a "재연결 필요" badge and drives the
+		// reconnect. (Ordered after the nil check: a deleted workspace's 404
+		// route-guard signal outranks a stale credential badge. Not logged here —
+		// the SPA polls this every few seconds and the 401 that raised the flag
+		// is already logged once at its source.)
+		view := s.setStatus(workspaceView(ws))
+		view["reconnect"] = true
+		writeJSON(w, http.StatusOK, view)
 		return
 	}
 	writeJSON(w, http.StatusOK, s.setStatus(workspaceView(ws)))

--- a/internal/console/workspace_test.go
+++ b/internal/console/workspace_test.go
@@ -48,10 +48,11 @@ func decodeErrorBody(t *testing.T, rr *httptest.ResponseRecorder) map[string]str
 }
 
 // TestWorkspaceStatusCloudAuthExpired: once the data plane records a rejected
-// refresh credential, GET /api/v1/workspace must surface the doc's 502
-// CLOUD_AUTH_EXPIRED (the SC-03 badge feed) instead of a healthy 200 — the
-// workspace itself is fine, but the data plane cannot restore itself without a
-// session-driven reconnect. A cleared flag returns the status to 200.
+// refresh credential, GET /api/v1/workspace flags reconnect:true on a 200 (the
+// SC-03 badge feed) rather than erroring — the workspace itself is fine, but the
+// data plane cannot restore itself without a session-driven reconnect. Surfacing
+// it as a flag (like orphaned) keeps the SPA's poll loop alive and the badge
+// populated; a 502 would blank both. A cleared flag drops the reconnect flag.
 func TestWorkspaceStatusCloudAuthExpired(t *testing.T) {
 	ts := mockCloud(t, "rs1.runespace.example")
 	h, dp, cookie := newWorkspaceHarness(t, ts.URL)
@@ -61,11 +62,15 @@ func TestWorkspaceStatusCloudAuthExpired(t *testing.T) {
 	req.AddCookie(cookie)
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
-	if rr.Code != http.StatusBadGateway {
-		t.Fatalf("status = %d, want 502", rr.Code)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
 	}
-	if body := decodeErrorBody(t, rr); body["code"] != "CLOUD_AUTH_EXPIRED" {
-		t.Errorf("code = %q, want CLOUD_AUTH_EXPIRED", body["code"])
+	var expired map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &expired); err != nil {
+		t.Fatalf("workspace body is not JSON: %v (%s)", err, rr.Body.String())
+	}
+	if expired["reconnect"] != true {
+		t.Errorf("reconnect = %v, want true (%s)", expired["reconnect"], rr.Body.String())
 	}
 
 	// A successful exchange lowers the flag; the poll goes healthy again.
@@ -92,6 +97,9 @@ func TestWorkspaceStatusCloudAuthExpired(t *testing.T) {
 	}
 	if _, ok := view["host"]; ok {
 		t.Errorf("body still carries the off-contract `host` key: %v", rr.Body.String())
+	}
+	if view["reconnect"] == true {
+		t.Errorf("reconnect flag still set after recovery: %v", rr.Body.String())
 	}
 }
 

--- a/internal/server/console_api.go
+++ b/internal/server/console_api.go
@@ -363,6 +363,7 @@ func (h *consoleAPI) renameTeam(w http.ResponseWriter, r *http.Request) {
 type memberDTO struct {
 	UserID           string `json:"userId"`
 	Account          string `json:"account"`
+	Username         string `json:"username"`
 	Role             string `json:"role"`
 	InvitationStatus string `json:"invitationStatus"`
 	SessionStatus    string `json:"sessionStatus"`
@@ -411,8 +412,9 @@ func (h *consoleAPI) teamMembers(w http.ResponseWriter, r *http.Request) {
 
 func (h *consoleAPI) addTeamMember(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		Account string `json:"account"`
-		Role    string `json:"role"`
+		Account  string `json:"account"`
+		Username string `json:"username"`
+		Role     string `json:"role"`
 	}
 	if err := readJSON(r, &body); err != nil {
 		apiErr(w, http.StatusBadRequest, "VALIDATION_ERROR", err.Error())
@@ -430,14 +432,20 @@ func (h *consoleAPI) addTeamMember(w http.ResponseWriter, r *http.Request) {
 	}
 	// The org admin (Owner) may hold a normal team membership like anyone else:
 	// admin-ness is an independent axis (IsOrgAdmin governs grant authority), not
-	// a bar to membership. But the admin is not auto-seeded a member row, so
-	// adding the owner's own email through this "add existing member" path 404s
-	// (USER_NOT_FOUND) until they have been invited (the invite flow creates the
-	// row). Memory access is still governed by the granted role.
+	// a bar to membership. An unknown account is created on the spot (mirroring
+	// the invite flow), stamping the supplied username as its display name — the
+	// team screen's "add member" is a create-or-attach, not existing-only.
 	m, err := h.ms.members.GetByEmail(body.Account)
+	newMember := false
 	if err != nil {
-		apiErr(w, http.StatusNotFound, "USER_NOT_FOUND", "no registered user for account "+body.Account)
-		return
+		created, aerr := h.ms.members.Add(body.Account, body.Username)
+		if aerr != nil {
+			// GetByEmail missed, so a failed Add means a malformed account
+			// (ErrInvalidEmail) — report it in the console error shape.
+			apiErr(w, http.StatusBadRequest, "VALIDATION_ERROR", aerr.Error())
+			return
+		}
+		m, newMember = created, true
 	}
 	if _, exists, _ := h.v.Groups().DirectRole(m.ID, ref); exists {
 		apiErr(w, http.StatusConflict, "ALREADY_TEAM_MEMBER", "user is already a member of this team")
@@ -445,6 +453,9 @@ func (h *consoleAPI) addTeamMember(w http.ResponseWriter, r *http.Request) {
 	}
 	mem, err := h.v.Groups().Grant(m.ID, ref, role, localAdminActor(actorFromContext(r.Context())))
 	if err != nil {
+		if newMember {
+			_ = h.ms.members.Remove(m.ID)
+		}
 		writeGroupAPIErr(w, err)
 		return
 	}
@@ -455,6 +466,9 @@ func (h *consoleAPI) addTeamMember(w http.ResponseWriter, r *http.Request) {
 	if h.needsCode(m) {
 		if ierr := h.issueCode(r, m); ierr != nil {
 			_, _ = h.v.Groups().RevokeDirectGrant(m.ID, ref)
+			if newMember {
+				_ = h.ms.members.Remove(m.ID)
+			}
 			slog.Error("console: invite code send failed on add-member (membership rolled back)",
 				"account", body.Account, "team", ref, "err", ierr)
 			apiErr(w, http.StatusBadGateway, "MAIL_UPSTREAM_ERROR", "failed to send the invitation code email")

--- a/internal/server/console_api_users.go
+++ b/internal/server/console_api_users.go
@@ -37,6 +37,7 @@ type membershipDTO struct {
 type userDTO struct {
 	UserID           string `json:"userId"`
 	Account          string `json:"account"`
+	Username         string `json:"username"`
 	InvitationStatus string `json:"invitationStatus"`
 	SessionStatus    string `json:"sessionStatus"`
 	// Memberships is the user's DIRECT (explicit) memberships — the
@@ -74,6 +75,7 @@ func (u userDTO) MarshalJSON() ([]byte, error) {
 	return json.Marshal(userWire{
 		UserID:           u.UserID,
 		Account:          u.Account,
+		Username:         u.Username,
 		InvitationStatus: u.InvitationStatus,
 		SessionStatus:    u.SessionStatus,
 		Memberships:      merged,
@@ -90,6 +92,7 @@ func (u userDTO) MarshalJSON() ([]byte, error) {
 type userWire struct {
 	UserID           string          `json:"userId"`
 	Account          string          `json:"account"`
+	Username         string          `json:"username"`
 	InvitationStatus string          `json:"invitationStatus"`
 	SessionStatus    string          `json:"sessionStatus"`
 	Memberships      []membershipDTO `json:"memberships"`
@@ -314,6 +317,7 @@ func (idx *userIndex) userDTO(m members.Member) userDTO {
 	return userDTO{
 		UserID:               m.ID,
 		Account:              m.Email,
+		Username:             m.DisplayName,
 		InvitationStatus:     st.invitation,
 		SessionStatus:        st.session,
 		Memberships:          ms,
@@ -326,14 +330,15 @@ func (idx *userIndex) userDTO(m members.Member) userDTO {
 
 // memberDTO builds the team-member-table row for a membership.
 func (idx *userIndex) memberDTO(m groups.Membership) memberDTO {
-	account := ""
+	account, username := "", ""
 	st := memberStatuses{invitation: "invite_pending", session: "offline"}
 	if mem, ok := idx.memberByID[m.User]; ok {
-		account, st = mem.Email, idx.statuses(mem)
+		account, username, st = mem.Email, mem.DisplayName, idx.statuses(mem)
 	}
 	return memberDTO{
 		UserID:           m.User,
 		Account:          account,
+		Username:         username,
 		Role:             string(m.Role),
 		InvitationStatus: st.invitation,
 		SessionStatus:    st.session,
@@ -349,14 +354,15 @@ func (idx *userIndex) memberDTO(m groups.Membership) memberDTO {
 // read and joinedAt is null, since there is no grant to timestamp. Shown in the
 // team member table alongside direct members without distinction.
 func (idx *userIndex) inheritedMemberDTO(userID string) memberDTO {
-	account := ""
+	account, username := "", ""
 	st := memberStatuses{invitation: "invite_pending", session: "offline"}
 	if mem, ok := idx.memberByID[userID]; ok {
-		account, st = mem.Email, idx.statuses(mem)
+		account, username, st = mem.Email, mem.DisplayName, idx.statuses(mem)
 	}
 	return memberDTO{
 		UserID:           userID,
 		Account:          account,
+		Username:         username,
 		Role:             string(groups.RoleRead),
 		InvitationStatus: st.invitation,
 		SessionStatus:    st.session,
@@ -387,15 +393,15 @@ func (h *consoleAPI) usersList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// sort is an enum (doc §users): last_invited (default) | account. Reject an
-	// out-of-enum value with 400 rather than silently ignoring it (which makes
-	// the client's sort dropdown appear to do nothing), mirroring the
+	// sort is an enum (doc §users): last_invited (default) | username | account.
+	// Reject an out-of-enum value with 400 rather than silently ignoring it (which
+	// makes the client's sort dropdown appear to do nothing), mirroring the
 	// status-filter check above and the invitationsHistory sort validation.
 	sortKey := strings.TrimSpace(q.Get("sort"))
 	if sortKey == "" {
 		sortKey = "last_invited"
 	}
-	if sortKey != "last_invited" && sortKey != "account" {
+	if sortKey != "last_invited" && sortKey != "username" && sortKey != "account" {
 		apiErr(w, http.StatusBadRequest, "VALIDATION_ERROR", "unknown sort: "+sortKey)
 		return
 	}
@@ -405,7 +411,9 @@ func (h *consoleAPI) usersList(w http.ResponseWriter, r *http.Request) {
 	items := make([]userDTO, 0, len(idx.memberByID))
 	for _, m := range h.ms.members.List() {
 		u := idx.userDTO(m)
-		if search != "" && !strings.Contains(strings.ToLower(u.Account), search) {
+		if search != "" &&
+			!strings.Contains(strings.ToLower(u.Account), search) &&
+			!strings.Contains(strings.ToLower(u.Username), search) {
 			continue
 		}
 		if statusFilter != "" && u.SessionStatus != statusFilter {
@@ -417,6 +425,15 @@ func (h *consoleAPI) usersList(w http.ResponseWriter, r *http.Request) {
 		items = append(items, u)
 	}
 	switch sortKey {
+	case "username":
+		// Display name ascending; account tiebreak so equal/empty names stay
+		// deterministic.
+		sort.SliceStable(items, func(i, j int) bool {
+			if items[i].Username != items[j].Username {
+				return items[i].Username < items[j].Username
+			}
+			return items[i].Account < items[j].Account
+		})
 	case "account":
 		// Account ascending (byte order — deterministic and stable).
 		sort.SliceStable(items, func(i, j int) bool {
@@ -756,6 +773,7 @@ func (h *consoleAPI) userMembershipsRemoveBatch(w http.ResponseWriter, r *http.R
 func (h *consoleAPI) createInvitation(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Account     string `json:"account"`
+		Username    string `json:"username"`
 		Memberships []struct {
 			TeamID string `json:"teamId"`
 			Role   string `json:"role"`
@@ -793,7 +811,7 @@ func (h *consoleAPI) createInvitation(w http.ResponseWriter, r *http.Request) {
 	m, gerr := h.ms.members.GetByEmail(body.Account)
 	newMember := false
 	if gerr != nil {
-		created, aerr := h.ms.members.Add(body.Account, "")
+		created, aerr := h.ms.members.Add(body.Account, body.Username)
 		if aerr != nil {
 			// GetByEmail missed, so a failed Add means a malformed account
 			// (ErrInvalidEmail) — report it in the console error shape.
@@ -849,6 +867,7 @@ func (h *consoleAPI) createInvitation(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, map[string]any{
 		"userId":           m.ID,
 		"account":          m.Email,
+		"username":         m.DisplayName,
 		"invitationStatus": st.invitation,
 		"sessionStatus":    st.session,
 		"codeSent":         codeSent,
@@ -951,6 +970,7 @@ func (h *consoleAPI) invitationsHistory(w http.ResponseWriter, r *http.Request) 
 	}
 	type historyRow struct {
 		Account      string  `json:"account"`
+		Username     string  `json:"username"`
 		IssuedAt     string  `json:"issuedAt"`
 		LastAccessAt *string `json:"lastAccessAt"`
 	}
@@ -964,19 +984,29 @@ func (h *consoleAPI) invitationsHistory(w http.ResponseWriter, r *http.Request) 
 		if tl, ok := idx.tokenByEmail[inv.Email]; ok && tl.lastUsed != "" {
 			la = wireTimePtr(tl.lastUsed)
 		}
-		rows = append(rows, historyRow{Account: inv.Email, IssuedAt: wireTime(inv.CreatedAt), LastAccessAt: la})
+		rows = append(rows, historyRow{
+			Account:      inv.Email,
+			Username:     idx.memberByID[inv.MemberID].DisplayName,
+			IssuedAt:     wireTime(inv.CreatedAt),
+			LastAccessAt: la,
+		})
 	}
 	// ?sort (design doc §invitations): last_access (DEFAULT — most-recent
 	// access first, rows with no access sink to the bottom) | issued_at
-	// (newest first) | account (A→Z). An empty param takes the last_access
-	// default; List() already yields issued_at desc.
+	// (newest first) | username (A→Z by display name, account tiebreak). An empty
+	// param takes the last_access default; List() already yields issued_at desc.
 	sortKey := r.URL.Query().Get("sort")
 	if sortKey == "" {
 		sortKey = "last_access"
 	}
 	switch sortKey {
-	case "account":
-		sort.SliceStable(rows, func(i, j int) bool { return rows[i].Account < rows[j].Account })
+	case "username":
+		sort.SliceStable(rows, func(i, j int) bool {
+			if rows[i].Username != rows[j].Username {
+				return rows[i].Username < rows[j].Username
+			}
+			return rows[i].Account < rows[j].Account
+		})
 	case "issued_at":
 		// already issued_at desc from List() — no-op
 	case "last_access":

--- a/internal/updater/systemd_unit_test.go
+++ b/internal/updater/systemd_unit_test.go
@@ -1,0 +1,48 @@
+package updater
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRuneconsoleSystemdSandboxKeepsUpdateHandoffOnOneMount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		path          string
+		wantMount     string
+		separateMount string
+	}{
+		{
+			name:          "checked-in unit",
+			path:          filepath.Join("..", "..", "deployment", "systemd", "runeconsole.service"),
+			wantMount:     "ReadWritePaths=/opt/runeconsole /var/lib/runeconsole-updater",
+			separateMount: "ReadWritePaths=/opt/runeconsole /var/lib/runeconsole-updater/inbox /var/lib/runeconsole-updater/staging",
+		},
+		{
+			name:          "installer-generated unit",
+			path:          filepath.Join("..", "..", "install.sh"),
+			wantMount:     `"ReadWritePaths=${INSTALL_PREFIX} ${UPDATE_STATE_DIR}"`,
+			separateMount: `"ReadWritePaths=${INSTALL_PREFIX} ${UPDATE_INBOX_DIR} ${UPDATE_STAGING_DIR}"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			body, err := os.ReadFile(test.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			unit := string(body)
+			if strings.Contains(unit, test.separateMount) {
+				t.Fatalf("%s gives inbox and staging separate systemd bind mounts; link(2) cannot publish the staged request across them", test.path)
+			}
+			if !strings.Contains(unit, test.wantMount) {
+				t.Fatalf("%s does not expose the shared updater root as one writable systemd mount", test.path)
+			}
+		})
+	}
+}

--- a/internal/updater/webupdate.go
+++ b/internal/updater/webupdate.go
@@ -431,6 +431,14 @@ func newUpdateJobID() (string, error) {
 }
 
 func enqueueUpdateRequest(stagingDir, requestPath string, request UpdateJobRequest) error {
+	return enqueueUpdateRequestWithLink(stagingDir, requestPath, request, os.Link)
+}
+
+func enqueueUpdateRequestWithLink(
+	stagingDir, requestPath string,
+	request UpdateJobRequest,
+	link func(string, string) error,
+) error {
 	if err := validateUpdateJobRequest(request); err != nil {
 		return err
 	}
@@ -447,10 +455,47 @@ func enqueueUpdateRequest(stagingDir, requestPath string, request UpdateJobReque
 	if err != nil {
 		return err
 	}
-	tempPath := filepath.Join(resolvedStaging, ".request-"+request.JobID)
+	tempPath, err := stageUpdateRequest(resolvedStaging, request.JobID, body)
+	if err != nil {
+		return err
+	}
+	defer removeStagedUpdateRequest(tempPath)
+
+	// A hard link is the publish point: the watcher sees either no request or
+	// the complete, fsynced JSON inode. Unlike Rename, Link cannot overwrite a
+	// request another browser/session already queued.
+	linkErr := link(tempPath, resolvedRequest)
+	if errors.Is(linkErr, syscall.EXDEV) {
+		// Older systemd units exposed staging and inbox as separate
+		// ReadWritePaths. systemd turns each path into its own bind mount, so
+		// link(2) reports EXDEV even when both directories are on the same
+		// filesystem. Restage inside the already-validated inbox and retain the
+		// same atomic, no-overwrite hard-link publication semantics.
+		inboxTempPath, fallbackErr := stageUpdateRequest(filepath.Dir(resolvedRequest), request.JobID, body)
+		if fallbackErr != nil {
+			return fallbackErr
+		}
+		defer removeStagedUpdateRequest(inboxTempPath)
+		linkErr = link(inboxTempPath, resolvedRequest)
+	}
+	if linkErr != nil {
+		if errors.Is(linkErr, fs.ErrExist) || errors.Is(linkErr, syscall.EEXIST) {
+			return ErrUpdateInProgress
+		}
+		return fmt.Errorf("publish update request: %w", linkErr)
+	}
+	if err := syncDirectory(filepath.Dir(resolvedRequest)); err != nil {
+		_ = os.Remove(resolvedRequest)
+		return errors.New("persist update request directory failed")
+	}
+	return nil
+}
+
+func stageUpdateRequest(directory, jobID string, body []byte) (string, error) {
+	tempPath := filepath.Join(directory, ".request-"+jobID)
 	fd, err := syscall.Open(tempPath, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_EXCL|syscall.O_NOFOLLOW|syscall.O_CLOEXEC, 0o600)
 	if err != nil {
-		return fmt.Errorf("stage update request: %w", err)
+		return "", fmt.Errorf("stage update request: %w", err)
 	}
 	f := os.NewFile(uintptr(fd), "runeconsole-update-request")
 	_, writeErr := f.Write(body)
@@ -458,26 +503,14 @@ func enqueueUpdateRequest(stagingDir, requestPath string, request UpdateJobReque
 	closeErr := f.Close()
 	if err := errors.Join(writeErr, syncErr, closeErr); err != nil {
 		_ = os.Remove(tempPath)
-		return errors.New("persist update request failed")
+		return "", errors.New("persist update request failed")
 	}
-	defer func() {
-		_ = os.Remove(tempPath)
-		_ = syncDirectory(resolvedStaging)
-	}()
-	// A hard link is the publish point: the watcher sees either no request or
-	// the complete, fsynced JSON inode. Unlike Rename, Link cannot overwrite a
-	// request another browser/session already queued.
-	if err := os.Link(tempPath, resolvedRequest); err != nil {
-		if errors.Is(err, fs.ErrExist) || errors.Is(err, syscall.EEXIST) {
-			return ErrUpdateInProgress
-		}
-		return fmt.Errorf("publish update request: %w", err)
-	}
-	if err := syncDirectory(filepath.Dir(resolvedRequest)); err != nil {
-		_ = os.Remove(resolvedRequest)
-		return errors.New("persist update request directory failed")
-	}
-	return nil
+	return tempPath, nil
+}
+
+func removeStagedUpdateRequest(path string) {
+	_ = os.Remove(path)
+	_ = syncDirectory(filepath.Dir(path))
 }
 
 func peekUpdateRequest(path string) (UpdateJobRequest, error) {

--- a/internal/updater/webupdate_test.go
+++ b/internal/updater/webupdate_test.go
@@ -416,6 +416,32 @@ func TestUpdateRequestAndStatusFilesAreStrictAndAtomic(t *testing.T) {
 			t.Fatalf("staging leaked %d files", len(entries))
 		}
 	})
+	t.Run("cross-mount staging falls back to the inbox", func(t *testing.T) {
+		env := newWebControlTestEnv(t, true)
+		request := UpdateJobRequest{JobID: "abcdefghijklmnop", TargetVersion: "v1.1.0", RequestedAt: time.Now().UTC()}
+		linkCalls := 0
+		link := func(oldPath, newPath string) error {
+			linkCalls++
+			if linkCalls == 1 {
+				return syscall.EXDEV
+			}
+			return os.Link(oldPath, newPath)
+		}
+		if err := enqueueUpdateRequestWithLink(env.paths.Staging, env.paths.Request, request, link); err != nil {
+			t.Fatalf("enqueue across sandbox mounts: %v", err)
+		}
+		if linkCalls != 2 {
+			t.Fatalf("link calls = %d, want primary attempt plus inbox fallback", linkCalls)
+		}
+		entries, err := os.ReadDir(env.paths.Staging)
+		if err != nil || len(entries) != 0 {
+			t.Fatalf("staging entries after fallback = %v, %v", entries, err)
+		}
+		got, err := ConsumeUpdateRequest(env.paths.Request)
+		if err != nil || got.JobID != request.JobID {
+			t.Fatalf("consume fallback request = %+v, %v", got, err)
+		}
+	})
 	t.Run("strict request JSON", func(t *testing.T) {
 		env := newWebControlTestEnv(t, true)
 		body := `{"jobId":"abcdefghijklmnop","targetVersion":"v1.1.0","requestedAt":"2026-07-20T00:00:00Z","binaryPath":"/tmp/evil"}`


### PR DESCRIPTION
## What

Rolls `release/v1.0.2` up to `main`. The bulk of this branch is a frontend-as-SSOT audit of the console API: the React app was treated as the single source of truth and every endpoint it calls was diffed against the Go backend. The audit surfaced one systemic gap — the member display name (`username`) was never threaded through the Go layer — plus a workspace-reconnect UX hole. Both are fixed here.

## Changes

### `fix(console-api): thread member display name (username) end to end` (f9506d1)

The frontend sends `username` on `POST /invitations` and `POST /teams/{id}/members`, and reads it back on the user list, user detail, team-member table, and invite history. The Go layer never carried `members.Member.DisplayName` across the boundary, which broke two things:

- **`DisallowUnknownFields` rejected the unknown `username` field with a 400** — creating an invitation and adding a team member were *fully broken* (this is the invite 400 hit in the field).
- **`sort=username` 400'd** on both `GET /users` and `GET /invitations`, since neither sort switch recognized the display-name key the UI sends.

Fix: accept + persist `username` (an existing member keeps its stored name), emit it in `memberDTO` / `userDTO` / the invite 201 response / the invite-history row, accept `sort=username` on both list endpoints, and match the display name in the `/users` search. Add-member now also creates an unknown account (create-or-attach, mirroring the invite flow) instead of 404ing, rolling the new member back on a mail failure.

### `feat(workspace): surface an expired data-plane credential as a reconnect flag` (36b17ea)

`GET /workspace` returned `502 CLOUD_AUTH_EXPIRED`, which the SPA had no consumer for → the navbar badge went blank, the poll loop stopped, and there was no reconnect affordance. Now surfaced as a `reconnect: true` flag on the 200 view (the same pattern as `orphaned`): the badge stays populated, polling stays alive, and the workspace modal offers a reconnect action that re-bootstraps the credential via `POST /workspace`.

### `test(mock): add system/update routes to the mock server` (51181de)

The mock server had no `/api/v1/system/update` route, so the update card had no intended-contract reference. Added `GET` (UpdateStatus shape) and `POST {version}` → 202, mirroring the backend's contract and error codes.

### Also included (already on the branch, not from this work)

- `f45976e` fix(updater): handle systemd cross-mount publishing
- `56cb50f` fix(installer): drop the CSP tunnel shim on local installs

## Verification

- Go: `go build ./...` + `go test ./...` — all 11 packages pass (the workspace 502→reconnect test was updated to the new contract).
- Frontend: `tsc` clean, `vitest` 315 tests pass.
