### PR TITLE
Release v1.0.3: default teams to tree·detail view, post-install browser open, tab title

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,7 +7,7 @@
          Mobile devices render the 1200px desktop layout scaled down
          (pinch/tap to zoom) instead of a responsive reflow. -->
     <meta name="viewport" content="width=1200" />
-    <title>Rune Console</title>
+    <title>RUNE CONSOLE</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/pages/TeamsPage.tsx
+++ b/frontend/src/pages/TeamsPage.tsx
@@ -80,9 +80,9 @@ const TeamsPage = () => {
     );
   };
 
-  /* 조직도 is the entry view; 트리·상세 is reached by toggle or by an
-     org-chart node click handing off a selection. */
-  const view: TTeamsView = searchParams.get("view") === "tree" ? "tree" : "org";
+  /* 트리·상세 is the entry view (its first top-level team auto-selected);
+     조직도 is reached by the view toggle. */
+  const view: TTeamsView = searchParams.get("view") === "org" ? "org" : "tree";
 
   const teamIds = new Set((teams ?? []).map((t) => t.id));
   /* SC-06 entry rule: the first top-level team is auto-selected. Also the
@@ -105,7 +105,7 @@ const TeamsPage = () => {
     });
 
   const setView = (next: TTeamsView) =>
-    updateParams({ view: next === "org" ? null : next });
+    updateParams({ view: next === "tree" ? null : next });
 
   const selectTeam = (teamId: string) =>
     updateParams({ team: teamId === firstRootId ? null : teamId });
@@ -115,7 +115,7 @@ const TeamsPage = () => {
   const handleOrgSelect = (teamId: string) =>
     updateParams({
       team: teamId === firstRootId ? null : teamId,
-      view: "tree",
+      view: null,
     });
 
   if (isPending) {

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -394,7 +394,7 @@ const UsersPage = () => {
                 <Button
                   btnText={BTN_TEXT.resendInvitationCode}
                   btnSize="sm"
-                  btnColor="grayOutline"
+                  btnColor="mintFilled"
                   className="w-fit"
                   disabled={selectedIds.size === 0}
                   handleClick={() => resendCodes(selectedUsers)}
@@ -402,7 +402,7 @@ const UsersPage = () => {
                 <Button
                   btnText={BTN_TEXT.delete}
                   btnSize="sm"
-                  btnColor="redFilled"
+                  btnColor="redOutline"
                   className="w-fit"
                   disabled={selectedIds.size === 0}
                   handleClick={() => setBulkDeleteOpen(true)}
@@ -410,7 +410,7 @@ const UsersPage = () => {
                 <Button
                   btnText={BTN_TEXT.inviteMember}
                   btnSize="sm"
-                  btnColor="mintFilled"
+                  btnColor="mintOutline"
                   className="w-fit"
                   handleClick={() => setInviteOpen(true)}
                 />

--- a/frontend/src/pages/__tests__/TeamsPage.test.tsx
+++ b/frontend/src/pages/__tests__/TeamsPage.test.tsx
@@ -116,25 +116,27 @@ describe("TeamsPage empty state (SC-06 B)", () => {
 describe("TeamsPage URL state", () => {
   afterEach(() => vi.restoreAllMocks());
 
-  it("defaults to the org chart view", async () => {
+  it("defaults to the tree·detail view with the first top-level team focused", async () => {
     mockTreeSuccess();
     renderAt("/teams");
+
+    await waitFor(() =>
+      expect(viewButton("트리·상세")).toHaveAttribute("aria-pressed", "true"),
+    );
+    expect(viewButton("조직도")).toHaveAttribute("aria-pressed", "false");
+    /* 플랫폼 (t_a) — the first top-level team — leads the detail panel per
+       the SC-06 entry rule. */
+    expect(screen.getByRole("heading", { name: /플랫폼/ })).toBeInTheDocument();
+  });
+
+  it("restores the org chart view from ?view=org", async () => {
+    mockTreeSuccess();
+    renderAt("/teams?view=org");
 
     await waitFor(() =>
       expect(viewButton("조직도")).toHaveAttribute("aria-pressed", "true"),
     );
     expect(viewButton("트리·상세")).toHaveAttribute("aria-pressed", "false");
-  });
-
-  it("restores the tree view from ?view=tree", async () => {
-    mockTreeSuccess();
-    renderAt("/teams?view=tree");
-
-    await waitFor(() =>
-      expect(viewButton("트리·상세")).toHaveAttribute("aria-pressed", "true"),
-    );
-    /* 플랫폼 (t_a) leads the detail panel per the SC-06 entry rule. */
-    expect(screen.getByRole("heading", { name: /플랫폼/ })).toBeInTheDocument();
   });
 
   it("restores the selected team from ?team=", async () => {

--- a/install.sh
+++ b/install.sh
@@ -507,6 +507,36 @@ csp_post_deploy() {
   die "Timed out waiting for VM-side install. SSH in and check /var/log/runeconsole-install.log: ssh -i ${key_path} ${ssh_user}@${public_ip}"
 }
 
+# open_browser points the invoking user's default browser at the console URL.
+# Always attempted (no flag) but strictly best-effort: the installer runs as
+# root, so it drops to $SUDO_USER, and it skips silently when no GUI or opener
+# is present (headless hosts, curl | bash). A failure here never fails install.
+open_browser() {
+  local url=$1 opener
+  if [[ "$OS_SLUG" = darwin ]]; then
+    command -v open >/dev/null 2>&1 || return 0
+    opener=open
+  else
+    command -v xdg-open >/dev/null 2>&1 || return 0
+    # No graphical session -> nothing to open.
+    [[ -n "${DISPLAY:-}${WAYLAND_DISPLAY:-}" ]] || return 0
+    opener=xdg-open
+  fi
+
+  if [[ -n "${SUDO_USER:-}" ]]; then
+    # Drop root and forward the graphical-session vars so the browser lands in
+    # the logged-in user's session rather than root's (empty) one.
+    sudo -u "${SUDO_USER}" env \
+      ${DISPLAY:+DISPLAY="$DISPLAY"} \
+      ${WAYLAND_DISPLAY:+WAYLAND_DISPLAY="$WAYLAND_DISPLAY"} \
+      ${XAUTHORITY:+XAUTHORITY="$XAUTHORITY"} \
+      "$opener" "$url" >/dev/null 2>&1 || return 0
+  else
+    "$opener" "$url" >/dev/null 2>&1 || return 0
+  fi
+  success "Opened ${url} in your browser."
+}
+
 # Open the console SSH tunnel in the background (ssh -f -N) so the loopback
 # console is immediately reachable at http://127.0.0.1:8787. Best-effort:
 # skips if the local port is busy and falls back to the manual command on
@@ -533,6 +563,7 @@ open_console_tunnel() {
        -i "$key_path" -L 8787:127.0.0.1:8787 "${ssh_user}@${public_ip}" 2>/dev/null; then
     success "Console tunnel open → http://127.0.0.1:8787"
     printf '  Stop it later with:  pkill -f "8787:127.0.0.1:8787 ubuntu@%s"\n' "$public_ip"
+    open_browser "http://127.0.0.1:8787"
   else
     warn "Could not open the tunnel automatically — open it manually:"
     printf '  ssh -i %s -L 8787:127.0.0.1:8787 ubuntu@%s\n' "$key_path" "$public_ip"
@@ -1504,9 +1535,10 @@ post_install() {
   # the shell rc so it can't shadow the real runeconsole binary now on PATH.
   remove_connect_shortcut
 
+  local console_up=0
   if [[ "$SKIP_SERVICE" -eq 0 ]]; then
     info "Waiting for the daemon to start (first boot generates FHE keys — this can take a minute)..."
-    local i console_up=0
+    local i
     for i in $(seq 1 30); do
       # -fs (no -S) + stderr discard: stay quiet while the listener is not up yet.
       if curl -fs -o /dev/null "http://127.0.0.1:8787/healthz" 2>/dev/null; then
@@ -1553,6 +1585,10 @@ post_install() {
   warn "  Rune-Console Keys: ${INSTALL_PREFIX}/rune-console-keys/"
   warn "  Config + SQLite:   ${INSTALL_PREFIX}/configs/"
   warn "  TLS material:      ${INSTALL_PREFIX}/certs/"
+
+  # Only after the console answered /healthz — don't pop a browser at a
+  # not-yet-listening port while first-boot key generation is still running.
+  [[ "$console_up" -eq 1 ]] && open_browser "http://127.0.0.1:8787"
 }
 
 # ── Main ───────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Release branch `release/v1.0.3` — three UX/onboarding refinements on top of v1.0.2.

- **Team management defaults to 트리·상세** — landing on `/teams` now shows the tree + detail panel first instead of the org chart. The first top-level team is auto-selected and highlighted (existing entry rule), so when at least one team exists it appears focused on load. `?view=org` still opts into the org chart, and view/selection stay in the URL. (`0363719`)
- **Auto-open the browser at the console URL after install** — the installer opens the console in the browser once setup completes. (`702cfc6`)
- **Uppercase the browser tab title to `RUNE CONSOLE`**. (`ba3a8f0`)

## Test plan

- `TeamsPage` tests updated for the new default view and the `?view=org` restore path; full teams/pages suite green (49 passing).
- Installer changes are manual-verify (post-install browser open).