### PR TITLE
Release v1.0.4

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -108,8 +108,10 @@ jobs:
           fi
           export CGO_LDFLAGS="-L${STATIC_LIB_DIR}"
           mkdir -p bin
+          # No -trimpath: it strips -ldflags from the binary's build info, and
+          # the privileged web updater verifies a candidate's release version by
+          # reading buildVersion back out of that recorded -ldflags setting.
           go build \
-            -trimpath \
             -ldflags "-s -w -X '${PKG}.buildVersion=${VERSION}' -X '${PKG}.buildCommit=${COMMIT}' -X '${PKG}.buildDate=${DATE}'" \
             -o bin/runeconsole \
             ./cmd

--- a/install.sh
+++ b/install.sh
@@ -570,14 +570,19 @@ open_console_tunnel() {
   fi
 }
 
-# _login_rc_file echoes the shell rc file for the invoking user's login shell
-# (zsh → .zshrc, bash → .bashrc, else .profile). Detection works under sudo:
-# passwd on Linux, dscl on macOS, $SHELL as a last resort. Shared by the
-# connect-shortcut install (CSP) and removal (local) paths.
-_login_rc_file() {
+# install_connect_shortcut writes a `runeconsole connect` command into the
+# invoking user's shell rc (zsh → .zshrc, bash → .bashrc, else .profile) so the
+# loopback console tunnel can be reopened later without retyping the ssh command.
+# Idempotent: a marker-delimited block is rewritten in place on re-install (so a
+# changed IP / key path propagates). If a real `runeconsole` binary is already on
+# PATH the shortcut is skipped so it is never shadowed.
+install_connect_shortcut() {
+  local key_path=$1 public_ip=$2
   local login_user="${SUDO_USER:-$(id -un)}"
   local user_home; user_home=$(eval echo "~${login_user}")
 
+  # Detect the login shell (works under sudo): passwd on Linux, dscl on macOS,
+  # $SHELL as a last resort — then map it to the rc file we append to.
   local login_shell=""
   if command -v getent >/dev/null 2>&1; then
     login_shell=$(getent passwd "$login_user" 2>/dev/null | cut -d: -f7)
@@ -587,38 +592,12 @@ _login_rc_file() {
   fi
   [[ -z "$login_shell" ]] && login_shell="${SHELL:-}"
 
+  local rc_file
   case "$login_shell" in
-    *zsh)  printf '%s/.zshrc\n'   "$user_home" ;;
-    *bash) printf '%s/.bashrc\n'  "$user_home" ;;
-    *)     printf '%s/.profile\n' "$user_home" ;;
+    *zsh)  rc_file="${user_home}/.zshrc" ;;
+    *bash) rc_file="${user_home}/.bashrc" ;;
+    *)     rc_file="${user_home}/.profile" ;;
   esac
-}
-
-# remove_connect_shortcut strips the marker-delimited `runeconsole connect`
-# tunnel shim from the invoking user's shell rc. The shim is a CSP-only helper;
-# on a local install a real `runeconsole` binary lands on PATH and a leftover
-# shell function from an earlier CSP install would shadow it, so the local path
-# always clears it. No-op when the block is absent.
-remove_connect_shortcut() {
-  local rc_file; rc_file=$(_login_rc_file)
-  local begin="# >>> runeconsole connect >>>"
-  [[ -f "$rc_file" ]] && grep -qF "$begin" "$rc_file" || return 0
-
-  local tmp; tmp=$(mktemp)
-  sed "/# >>> runeconsole connect >>>/,/# <<< runeconsole connect <<</d" "$rc_file" > "$tmp" && mv "$tmp" "$rc_file"
-  [[ -n "${SUDO_USER:-}" ]] && chown "${SUDO_USER}" "$rc_file" 2>/dev/null || true
-  info "Removed the CSP 'runeconsole connect' tunnel shim from ${rc_file} (a local install needs no tunnel)."
-}
-
-# install_connect_shortcut writes a `runeconsole connect` command into the
-# invoking user's shell rc (zsh → .zshrc, bash → .bashrc, else .profile) so the
-# loopback console tunnel can be reopened later without retyping the ssh command.
-# Idempotent: a marker-delimited block is rewritten in place on re-install (so a
-# changed IP / key path propagates). If a real `runeconsole` binary is already on
-# PATH the shortcut is skipped so it is never shadowed.
-install_connect_shortcut() {
-  local key_path=$1 public_ip=$2
-  local rc_file; rc_file=$(_login_rc_file)
 
   # Never shadow an existing runeconsole command on PATH.
   if command -v runeconsole >/dev/null 2>&1; then
@@ -1530,15 +1509,9 @@ install_service() {
 
 # ── Phase 8: Post-install summary ─────────────────────────────────────────────
 post_install() {
-  # A local install serves the console directly at 127.0.0.1:8787 and needs no
-  # tunnel. Clear any `runeconsole connect` shim an earlier CSP install left in
-  # the shell rc so it can't shadow the real runeconsole binary now on PATH.
-  remove_connect_shortcut
-
-  local console_up=0
   if [[ "$SKIP_SERVICE" -eq 0 ]]; then
     info "Waiting for the daemon to start (first boot generates FHE keys — this can take a minute)..."
-    local i
+    local i console_up=0
     for i in $(seq 1 30); do
       # -fs (no -S) + stderr discard: stay quiet while the listener is not up yet.
       if curl -fs -o /dev/null "http://127.0.0.1:8787/healthz" 2>/dev/null; then
@@ -1588,7 +1561,7 @@ post_install() {
 
   # Only after the console answered /healthz — don't pop a browser at a
   # not-yet-listening port while first-boot key generation is still running.
-  [[ "$console_up" -eq 1 ]] && open_browser "http://127.0.0.1:8787"
+  [[ "${console_up:-0}" -eq 1 ]] && open_browser "http://127.0.0.1:8787"
 }
 
 # ── Main ───────────────────────────────────────────────────────────────────────

--- a/internal/server/console_api_test.go
+++ b/internal/server/console_api_test.go
@@ -1,11 +1,13 @@
 package server
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"strings"
@@ -46,6 +48,43 @@ func newConsoleAPIFixture(t *testing.T) *consoleAPIFixture {
 	ts := httptest.NewServer(h)
 	t.Cleanup(ts.Close)
 	return &consoleAPIFixture{ts: ts, v: v, members: memStore, invites: invStore}
+}
+
+// newPersistentConsoleAPIFixture mirrors the daemon's shared write-through
+// store setup. Tests that need to assert the actual members/memberships/tokens
+// rows, rather than only the in-memory projections, use this fixture.
+func newPersistentConsoleAPIFixture(t *testing.T) (*consoleAPIFixture, *sql.DB) {
+	t.Helper()
+	database := openTokensTestDB(t, filepath.Join(t.TempDir(), "runeconsole.db"))
+
+	tokStore := tokens.NewStore()
+	if err := tokStore.LoadFromDB(database); err != nil {
+		t.Fatal(err)
+	}
+	gs := groups.NewStore()
+	gs.SetPersonKeyValidator(members.ValidateID)
+	if err := gs.LoadFromDB(database); err != nil {
+		t.Fatal(err)
+	}
+	memStore := members.NewStore()
+	if err := memStore.LoadFromDB(database); err != nil {
+		t.Fatal(err)
+	}
+	invStore := invites.NewStore()
+	if err := invStore.LoadFromDB(database); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &Config{
+		Tokens: TokensConfig{TeamSecret: "test-secret"},
+		Keys:   KeysConfig{Path: t.TempDir(), EmbeddingDim: 1024},
+	}
+	v := NewConsole(cfg, tokStore, gs, nil, nil)
+	mailer := &recordingMailer{}
+	h := NewConsoleAPIHandler(v, memStore, invStore, mailer, InviteConnInfo{ConsoleEndpoint: "c.example:8443"}, 30*time.Minute)
+	ts := httptest.NewServer(h)
+	t.Cleanup(ts.Close)
+	return &consoleAPIFixture{ts: ts, v: v, members: memStore, invites: invStore}, database
 }
 
 func (f *consoleAPIFixture) do(t *testing.T, method, path, body string) (int, []byte) {
@@ -483,6 +522,81 @@ func TestConsoleUsersDeleteBatchPartialFailure(t *testing.T) {
 	// Missing userIds param → 400 (guard against whole-collection delete).
 	if status, _ := f.do(t, http.MethodDelete, "/users", ""); status != http.StatusBadRequest {
 		t.Errorf("delete without userIds status=%d, want 400", status)
+	}
+}
+
+func TestConsoleUsersDeleteSelfInvitedAdminMemberState(t *testing.T) {
+	f, database := newPersistentConsoleAPIFixture(t)
+	const admin = "owner@corp.com"
+	f.v.Groups().SetOrgAdmin(admin)
+
+	team, err := f.v.Groups().CreateGroup("Admin-data-team", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inviteBody := `{"account":"` + admin + `","memberships":[{"teamId":"` + team.ID + `","role":"write"}]}`
+	status, body := f.do(t, http.MethodPost, "/invitations", inviteBody)
+	if status != http.StatusCreated {
+		t.Fatalf("invite admin: status=%d body=%s", status, body)
+	}
+	var invited struct {
+		UserID string `json:"userId"`
+	}
+	if err := json.Unmarshal(body, &invited); err != nil || invited.UserID == "" {
+		t.Fatalf("decode invited admin: err=%v body=%s", err, body)
+	}
+
+	status, body = f.do(t, http.MethodDelete, "/users?userIds="+invited.UserID, "")
+	if status != http.StatusOK {
+		t.Fatalf("delete admin member state: status=%d body=%s", status, body)
+	}
+	var deleted struct {
+		Succeeded []string `json:"succeeded"`
+		Failed    []struct {
+			ID   string `json:"id"`
+			Code string `json:"code"`
+		} `json:"failed"`
+	}
+	if err := json.Unmarshal(body, &deleted); err != nil {
+		t.Fatalf("decode delete response: %v (%s)", err, body)
+	}
+	if !slices.Equal(deleted.Succeeded, []string{invited.UserID}) || len(deleted.Failed) != 0 {
+		t.Fatalf("delete result = %+v, want the admin member row to succeed", deleted)
+	}
+
+	for table, key := range map[string]string{
+		"members":     "id",
+		"memberships": "user",
+		"tokens":      "user",
+	} {
+		value := invited.UserID
+		if table == "tokens" {
+			value = admin
+		}
+		var count int
+		query := fmt.Sprintf("SELECT count(*) FROM %s WHERE %s = ?", table, key)
+		if err := database.QueryRow(query, value).Scan(&count); err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		if count != 0 {
+			t.Errorf("%s rows after delete = %d, want 0", table, count)
+		}
+	}
+	var inviteStatus string
+	var tokenValue sql.NullString
+	if err := database.QueryRow(
+		`SELECT status, token_value FROM invites WHERE member_id = ?`, invited.UserID,
+	).Scan(&inviteStatus, &tokenValue); err != nil {
+		t.Fatalf("read invite history: %v", err)
+	}
+	if inviteStatus != invites.StatusRevoked || tokenValue.Valid {
+		t.Errorf("invite after delete = status %q token %v, want revoked with no token", inviteStatus, tokenValue)
+	}
+
+	// Admin authority is independent of the deleted member UUID. The BFF's
+	// console_owner/console_session database is likewise outside this handler.
+	if !f.v.Groups().IsOrgAdmin(admin) {
+		t.Error("deleting the admin's member state also erased org-admin authority")
 	}
 }
 

--- a/internal/server/console_api_users.go
+++ b/internal/server/console_api_users.go
@@ -511,24 +511,9 @@ func (h *consoleAPI) usersDeleteBatch(w http.ResponseWriter, r *http.Request) {
 			res.fail(id, "USER_NOT_FOUND", "no such user")
 			continue
 		}
-		// The org admin is not auto-seeded a member row (authority is email-keyed
-		// via SetOrgAdmin), so by default they are not in this batch at all. But
-		// if the admin invited their own email, that row carries their
-		// self-granted memberships, keyed by its UUID. Deleting it would drop
-		// those memberships and — since login no longer re-creates the row —
-		// leave no automatic restore. Revoking the admin's access is the
-		// supported operation (their memory reach is pure membership like
-		// anyone's); erasing the identity behind it is not. Refuse per-item so
-		// the rest of the batch still applies.
-		//
-		// The CODE is the contract the console renders from (it maps codes to
-		// its own copy); this message is for logs and direct API callers, so it
-		// states the refusal and nothing more — telling the operator what to do
-		// instead is the console's wording to choose, not ours.
-		if h.v.Groups().IsOrgAdmin(m.Email) {
-			res.fail(id, "CANNOT_DELETE_ADMIN", "the organization admin cannot be deleted")
-			continue
-		}
+		// A self-invited org admin follows the same member lifecycle as everyone
+		// else. Removing their member UUID and data-plane access does not erase
+		// the email-keyed org-admin identity or the separate console session.
 		// Cascade: destroy the session token, drop all group memberships, void
 		// any unused invite codes, then remove the member — in that order so the
 		// gRPC judge never sees a half-deleted identity (mirrors the admin


### PR DESCRIPTION
## 요약
`release/v1.0.4` → `main` 릴리스 PR. 아래 변경들이 누적되어 있습니다.

## 포함 커밋
- **`ci: drop -trimpath from release build so the updater can verify versions`**
  - 근본 원인: `-trimpath`는 바이너리의 Go build info에서 `-ldflags` 설정을 제거합니다. 권한 있는 웹 업데이터의 `BuildInfoVerifier`는 후보를 실행하지 않고 그 `-ldflags`에서 `buildVersion`을 읽어 릴리스 버전을 검증하는데, `-trimpath` 때문에 이 값이 없어 모든 후보가 `candidate build info does not contain the runeconsole release version`로 거부되어 in-place 업데이트가 실패했습니다.
  - 런타임 `runeconsole version`은 `-X` 주입이 링크 시점에 적용되어 정상이었고, buildinfo에 기록되는 설정만 누락된 상태였습니다. `-trimpath` 제거로 `-ldflags`가 다시 기록되어(작은따옴표 `-X` 값도 파서가 처리) 업데이트 경로가 동작합니다.
  - 실제 `BuildInfoVerifier`로 "trimpath 있음 → 거부(프로덕션과 동일 에러) / 없음 → 통과" e2e 검증 완료.
- **`fix: allow deleting admin member state` (PR #94, @heeyeon01)** — admin 멤버 삭제 허용.
- **`chore(install): consolidate connect-shortcut shell-rc helpers`** — `_login_rc_file`을 유일 호출자 `install_connect_shortcut`로 흡수하고 미사용 `remove_connect_shortcut` 제거. post-install 브라우저 오픈은 `${console_up:-0}` 가드로 `set -u` 안전성 유지.

## 릴리스 후속
머지 후 `v1.0.4` 태그를 찍으면 릴리스 워크플로가 `-trimpath` 없이 빌드하여, 웹 업데이터의 버전 검증이 통과하는 아티팩트를 생성합니다.