### PR TITLE
fix(teams): align inherited member metadata

### DIFF
--- a/internal/groups/console.go
+++ b/internal/groups/console.go
@@ -31,6 +31,19 @@ type ConsoleTeamDetail struct {
 	CreatedAt   string   `json:"createdAt"`
 }
 
+// ConsoleTeamMember is one row source for GET /teams/{id}/members. Direct
+// members retain their explicit role and source team. Inherited members are
+// projected as read, with SourceGroupID and GrantedAt taken from the nearest
+// direct ancestor membership. Keeping this projection in the store lets the
+// whole member list come from one consistent read snapshot.
+type ConsoleTeamMember struct {
+	User          string
+	Role          Role
+	SourceGroupID string
+	GrantedAt     string
+	Inherited     bool
+}
+
 // parentPtr maps an empty parent id (a root team) to nil so it serializes as
 // JSON null, per the design doc; a non-empty parent serializes as the string.
 func parentPtr(id string) *string {
@@ -40,15 +53,74 @@ func parentPtr(id string) *string {
 	return &id
 }
 
-// memberCountLocked counts direct memberships on group id. Caller holds s.mu.
-func (s *Store) memberCountLocked(id string) int {
+// effectiveMemberCountLocked counts the same people exposed by the team-member
+// list: direct members plus users who inherit read from a proper ancestor.
+// Direct+inherited overlap is counted once, and read exclusions are honored.
+// Caller holds s.mu.
+func (s *Store) effectiveMemberCountLocked(id string) int {
 	n := 0
-	for _, byGroup := range s.memberships {
+	for user, byGroup := range s.memberships {
 		if _, ok := byGroup[id]; ok {
+			n++
+			continue
+		}
+		if _, inherited := s.inheritedSourceLocked(user, id); inherited {
 			n++
 		}
 	}
 	return n
+}
+
+// effectiveMemberCountsLocked computes effective counts for every team in one
+// membership snapshot. groupAccessLocked already produces disjoint direct and
+// inherited sets with de-duplication and per-target exclusions applied.
+func (s *Store) effectiveMemberCountsLocked() map[string]int {
+	counts := make(map[string]int, len(s.groups))
+	for user, byGroup := range s.memberships {
+		access := s.groupAccessLocked(user, byGroup)
+		for _, m := range access.Direct {
+			counts[m.GroupID]++
+		}
+		for _, id := range access.Inherited {
+			counts[id]++
+		}
+	}
+	return counts
+}
+
+// ConsoleTeamMembers returns all people displayed for groupID — direct plus
+// recursively inherited — under one read lock. Unknown groups return nil.
+func (s *Store) ConsoleTeamMembers(groupID string) []ConsoleTeamMember {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if _, ok := s.groups[groupID]; !ok {
+		return nil
+	}
+	out := make([]ConsoleTeamMember, 0)
+	for user, byGroup := range s.memberships {
+		if direct, ok := byGroup[groupID]; ok {
+			out = append(out, ConsoleTeamMember{
+				User:          user,
+				Role:          direct.Role,
+				SourceGroupID: groupID,
+				GrantedAt:     direct.GrantedAt,
+			})
+			continue
+		}
+		source, inherited := s.inheritedSourceLocked(user, groupID)
+		if !inherited {
+			continue
+		}
+		out = append(out, ConsoleTeamMember{
+			User:          user,
+			Role:          RoleRead,
+			SourceGroupID: source.GroupID,
+			GrantedAt:     source.GrantedAt,
+			Inherited:     true,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].User < out[j].User })
+	return out
 }
 
 // sortedChildrenLocked returns id's child ids sorted by name — always non-nil
@@ -73,6 +145,7 @@ func (s *Store) ConsoleTree() []ConsoleTreeNode {
 		}
 	}
 	s.sortByNameLocked(roots)
+	memberCounts := s.effectiveMemberCountsLocked()
 
 	out := make([]ConsoleTreeNode, 0, len(s.groups))
 	var walk func(id string)
@@ -85,7 +158,7 @@ func (s *Store) ConsoleTree() []ConsoleTreeNode {
 			ParentID:    parentPtr(g.ParentID),
 			ChildrenIDs: kids,
 			ChildCount:  len(kids),
-			MemberCount: s.memberCountLocked(id),
+			MemberCount: memberCounts[id],
 		})
 		for _, c := range kids {
 			walk(c)
@@ -110,7 +183,7 @@ func (s *Store) TeamDetail(ref string) (ConsoleTeamDetail, error) {
 		Name:        g.Name,
 		ParentID:    parentPtr(g.ParentID),
 		Children:    s.sortedChildrenLocked(g.ID),
-		MemberCount: s.memberCountLocked(g.ID),
+		MemberCount: s.effectiveMemberCountLocked(g.ID),
 		CreatedAt:   g.CreatedAt,
 	}, nil
 }

--- a/internal/groups/console_test.go
+++ b/internal/groups/console_test.go
@@ -3,6 +3,7 @@ package groups
 import (
 	"errors"
 	"testing"
+	"time"
 )
 
 // findNode returns the console tree node with id, failing the test if absent.
@@ -55,8 +56,75 @@ func TestConsoleTreeCountsAndChildren(t *testing.T) {
 	if rn.ParentID != nil {
 		t.Errorf("root parentId = %v, want nil (null)", *rn.ParentID)
 	}
-	if cn.ChildCount != 0 || cn.MemberCount != 1 {
-		t.Errorf("child childCount=%d memberCount=%d, want 0 and 1", cn.ChildCount, cn.MemberCount)
+	if cn.ChildCount != 0 || cn.MemberCount != 3 {
+		t.Errorf("child childCount=%d memberCount=%d, want 0 and 3 effective members", cn.ChildCount, cn.MemberCount)
+	}
+}
+
+func TestConsoleTeamMembersUseNearestInheritanceSource(t *testing.T) {
+	s := NewStore()
+	root, _ := s.CreateGroup("Root", "")
+	mid, _ := s.CreateGroup("Mid", root.ID)
+	leaf, _ := s.CreateGroup("Leaf", mid.ID)
+
+	t0 := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	s.now = func() time.Time { return t0 }
+	rootOnly, err := s.Grant("root@x.com", root.ID, RoleEdit, "actor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Grant("nearest@x.com", root.ID, RoleRead, "actor"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Grant("excluded@x.com", root.ID, RoleWrite, "actor"); err != nil {
+		t.Fatal(err)
+	}
+
+	s.now = func() time.Time { return t0.Add(24 * time.Hour) }
+	midGrant, err := s.Grant("nearest@x.com", mid.ID, RoleWrite, "actor")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s.now = func() time.Time { return t0.Add(48 * time.Hour) }
+	direct, err := s.Grant("direct@x.com", leaf.ID, RoleEdit, "actor")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if excluded, err := s.ExcludeRead("excluded@x.com", leaf.ID, "actor"); err != nil || !excluded {
+		t.Fatalf("ExcludeRead = (%v, %v), want (true, nil)", excluded, err)
+	}
+
+	members := s.ConsoleTeamMembers(leaf.ID)
+	if len(members) != 3 {
+		t.Fatalf("effective members = %+v, want 3", members)
+	}
+	byUser := make(map[string]ConsoleTeamMember, len(members))
+	for _, m := range members {
+		byUser[m.User] = m
+	}
+	if got := byUser["root@x.com"]; !got.Inherited || got.Role != RoleRead || got.SourceGroupID != root.ID || got.GrantedAt != rootOnly.GrantedAt {
+		t.Errorf("root-only inherited member = %+v, want root source at %s", got, rootOnly.GrantedAt)
+	}
+	if got := byUser["nearest@x.com"]; !got.Inherited || got.Role != RoleRead || got.SourceGroupID != mid.ID || got.GrantedAt != midGrant.GrantedAt {
+		t.Errorf("multi-ancestor inherited member = %+v, want nearest mid source at %s", got, midGrant.GrantedAt)
+	}
+	if got := byUser["direct@x.com"]; got.Inherited || got.Role != RoleEdit || got.SourceGroupID != leaf.ID || got.GrantedAt != direct.GrantedAt {
+		t.Errorf("direct member = %+v, want leaf direct source at %s", got, direct.GrantedAt)
+	}
+	if _, found := byUser["excluded@x.com"]; found {
+		t.Error("read-excluded inherited member was listed")
+	}
+
+	detail, err := s.TeamDetail(leaf.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detail.MemberCount != len(members) {
+		t.Errorf("detail memberCount=%d, list len=%d", detail.MemberCount, len(members))
+	}
+	if node := findNode(t, s.ConsoleTree(), leaf.ID); node.MemberCount != len(members) {
+		t.Errorf("tree memberCount=%d, list len=%d", node.MemberCount, len(members))
 	}
 }
 

--- a/internal/groups/store.go
+++ b/internal/groups/store.go
@@ -728,13 +728,44 @@ func (s *Store) ExcludeRead(user, groupRef, removedBy string) (bool, error) {
 // downward inheritance — i.e. it is a descendant of one of their direct groups
 // and not already excluded. Caller must hold s.mu.
 func (s *Store) inheritsReadLocked(user, groupID string) bool {
-	if _, direct := s.memberships[user][groupID]; direct {
-		return false
+	_, ok := s.inheritedSourceLocked(user, groupID)
+	return ok
+}
+
+// inheritedSourceLocked returns the direct membership from which user inherits
+// read on groupID. A direct membership on groupID is not inheritance, and a
+// read exclusion removes the derived access. The proper ancestor chain is
+// walked from parent to root, so multiple qualifying grants resolve to the
+// nearest (most specific) source instead of depending on map iteration order.
+// Caller must hold s.mu.
+func (s *Store) inheritedSourceLocked(user, groupID string) (Membership, bool) {
+	byGroup := s.memberships[user]
+	if len(byGroup) == 0 {
+		return Membership{}, false
+	}
+	if _, direct := byGroup[groupID]; direct {
+		return Membership{}, false
 	}
 	if s.isExcludedLocked(user, groupID) {
-		return false
+		return Membership{}, false
 	}
-	return s.reachesByInheritanceLocked(user, groupID, "")
+	g, ok := s.groups[groupID]
+	if !ok {
+		return Membership{}, false
+	}
+	visited := make(map[string]bool, MaxTreeDepth)
+	for cur := g.ParentID; cur != "" && !visited[cur] && len(visited) < MaxTreeDepth; {
+		visited[cur] = true
+		if m, direct := byGroup[cur]; direct {
+			return *m, true
+		}
+		parent, exists := s.groups[cur]
+		if !exists {
+			break
+		}
+		cur = parent.ParentID
+	}
+	return Membership{}, false
 }
 
 // reachesByInheritanceLocked reports whether one of user's direct groups
@@ -772,48 +803,21 @@ func (s *Store) InheritsRead(user, groupID string) bool {
 	return s.inheritsReadLocked(user, groupID)
 }
 
-// Inheritors returns the sorted person keys that hold READ on groupID purely by
-// downward inheritance: every user with a direct membership on a PROPER ancestor
-// of groupID, minus those already direct on groupID (they are direct members,
-// not inheritors) and those with a read exclusion on it. It is the set
-// counterpart to InheritsRead — same predicate, evaluated for every user — but
-// computed by walking groupID's ancestor chain ONCE, so the cost is proportional
-// to the tree depth and the membership count, not to a per-user subtree collect.
-// Returns nil for an unknown group.
+// Inheritors returns the sorted person keys that reach groupID purely by
+// downward inheritance. ConsoleTeamMembers is the richer projection used by
+// the team endpoint; this compatibility view keeps callers that only need the
+// inherited user set on the same source-selection and exclusion semantics.
 func (s *Store) Inheritors(groupID string) []string {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	g, ok := s.groups[groupID]
-	if !ok {
+	members := s.ConsoleTeamMembers(groupID)
+	if members == nil {
 		return nil
 	}
-	// Proper ancestors of groupID (walk up the parent chain, depth-capped and
-	// cycle-guarded like every other ancestor walk here).
-	ancestors := make(map[string]bool, MaxTreeDepth)
-	for cur := g.ParentID; cur != "" && !ancestors[cur] && len(ancestors) < MaxTreeDepth; {
-		ancestors[cur] = true
-		p, ok := s.groups[cur]
-		if !ok {
-			break
-		}
-		cur = p.ParentID
-	}
 	out := make([]string, 0)
-	for user, byGroup := range s.memberships {
-		if _, direct := byGroup[groupID]; direct {
-			continue // a direct member of groupID, not an inheritor
-		}
-		if s.isExcludedLocked(user, groupID) {
-			continue
-		}
-		for gid := range byGroup {
-			if ancestors[gid] {
-				out = append(out, user)
-				break
-			}
+	for _, member := range members {
+		if member.Inherited {
+			out = append(out, member.User)
 		}
 	}
-	sort.Strings(out)
 	return out
 }
 

--- a/internal/server/console_api.go
+++ b/internal/server/console_api.go
@@ -367,11 +367,10 @@ type memberDTO struct {
 	Role             string `json:"role"`
 	InvitationStatus string `json:"invitationStatus"`
 	SessionStatus    string `json:"sessionStatus"`
-	// JoinedAt is the membership's granted_at. It is a pointer because an
-	// inherited-read member has no stored row and thus no join timestamp, so
-	// that row serializes joinedAt as null; a direct member always carries a
-	// real value. (Same nullable-timestamp convention as userDTO's stamps.)
-	JoinedAt *string `json:"joinedAt"`
+	// JoinedAt is the direct membership's granted_at, or for inherited read,
+	// the granted_at of the nearest direct ancestor membership that supplies
+	// the access. Every listed member therefore has a concrete join timestamp.
+	JoinedAt string `json:"joinedAt"`
 }
 
 func (h *consoleAPI) teamMembers(w http.ResponseWriter, r *http.Request) {
@@ -389,21 +388,10 @@ func (h *consoleAPI) teamMembers(w http.ResponseWriter, r *http.Request) {
 	}
 	idx := h.newIndex()
 	items := make([]memberDTO, 0)
-	// Direct members: the stored (user, group, role) rows on this team.
-	for _, m := range h.v.Groups().ListMemberships() {
-		if m.GroupID != gid {
-			continue
-		}
-		items = append(items, idx.memberDTO(m))
-	}
-	// Inherited-read members: users who reach this team only by downward
-	// inheritance from an ancestor membership (no stored row on this team).
-	// Groups().Inheritors computes this in the store (one ancestor-chain walk)
-	// and already excludes anyone direct on this team, so the two sets never
-	// overlap. Listed alongside direct members without distinction (API design
-	// decision), rendered as read with a null joinedAt.
-	for _, uid := range h.v.Groups().Inheritors(gid) {
-		items = append(items, idx.inheritedMemberDTO(uid))
+	// Direct and inherited rows are derived under one store read lock. Inherited
+	// rows carry the nearest source membership's granted_at as their joinedAt.
+	for _, member := range h.v.Groups().ConsoleTeamMembers(gid) {
+		items = append(items, idx.consoleTeamMemberDTO(member))
 	}
 	sort.Slice(items, func(i, j int) bool { return items[i].Account < items[j].Account })
 	pageItems, total := pageSlice(items, page, size)

--- a/internal/server/console_api_test.go
+++ b/internal/server/console_api_test.go
@@ -1243,20 +1243,24 @@ func TestUserDTOTimestampsRenderSecondPrecision(t *testing.T) {
 		User: m.ID, GroupID: "g1", Role: groups.RoleRead,
 		GrantedAt: "2026-07-07T08:12:00.900Z",
 	})
-	if dto.JoinedAt == nil || *dto.JoinedAt != "2026-07-07T08:12:00Z" {
+	if dto.JoinedAt != "2026-07-07T08:12:00Z" {
 		t.Errorf("joinedAt = %v, want 2026-07-07T08:12:00Z", dto.JoinedAt)
 	}
-	// An inherited-read member has no grant row, so joinedAt is null.
-	if inh := idx.inheritedMemberDTO(m.ID); inh.JoinedAt != nil {
-		t.Errorf("inherited joinedAt = %v, want nil", *inh.JoinedAt)
+	// An inherited-read row carries its nearest source membership's timestamp.
+	inh := idx.consoleTeamMemberDTO(groups.ConsoleTeamMember{
+		User: m.ID, Role: groups.RoleRead, SourceGroupID: "parent",
+		GrantedAt: "2026-07-06T03:04:05.678Z", Inherited: true,
+	})
+	if inh.JoinedAt != "2026-07-06T03:04:05Z" {
+		t.Errorf("inherited joinedAt = %v, want source timestamp 2026-07-06T03:04:05Z", inh.JoinedAt)
 	}
 }
 
 // TestConsoleTeamMembersIncludeInherited proves the team-member listing surfaces
 // inherited-read users (parent-group members) alongside direct members, rendered
-// as read with a null joinedAt, and that the team role batch PROMOTES such an
-// inherited user by creating a first-time direct grant — the whole point of the
-// inherited-inclusion change, driven end-to-end over HTTP.
+// as read with the source membership's joinedAt. It also proves team detail/tree
+// counts match that effective list and that the team role batch PROMOTES an
+// inherited user via a first-time direct grant, driven end-to-end over HTTP.
 func TestConsoleTeamMembersIncludeInherited(t *testing.T) {
 	f := newConsoleAPIFixture(t)
 	gs := f.v.Groups()
@@ -1274,22 +1278,24 @@ func TestConsoleTeamMembersIncludeInherited(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := gs.Grant(direct.ID, teamA.ID, groups.RoleWrite, "actor"); err != nil {
+	directGrant, err := gs.Grant(direct.ID, teamA.ID, groups.RoleWrite, "actor")
+	if err != nil {
 		t.Fatal(err)
 	}
 	boss, err := f.members.Add("boss@x.com", "")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := gs.Grant(boss.ID, hq.ID, groups.RoleEdit, "actor"); err != nil {
+	bossGrant, err := gs.Grant(boss.ID, hq.ID, groups.RoleEdit, "actor")
+	if err != nil {
 		t.Fatal(err)
 	}
 
 	type row struct {
-		UserID   string  `json:"userId"`
-		Account  string  `json:"account"`
-		Role     string  `json:"role"`
-		JoinedAt *string `json:"joinedAt"`
+		UserID   string `json:"userId"`
+		Account  string `json:"account"`
+		Role     string `json:"role"`
+		JoinedAt string `json:"joinedAt"`
 	}
 	rowsByUser := func() (int, map[string]row) {
 		_, body := f.do(t, http.MethodGet, "/teams/"+teamA.ID+"/members", "")
@@ -1312,11 +1318,38 @@ func TestConsoleTeamMembersIncludeInherited(t *testing.T) {
 	if total != 2 {
 		t.Fatalf("member total=%d, want 2 (%+v)", total, byUser)
 	}
-	if d := byUser[direct.ID]; d.Role != "write" || d.JoinedAt == nil {
-		t.Errorf("direct member = %+v, want role=write with a non-null joinedAt", d)
+	if d := byUser[direct.ID]; d.Role != "write" || d.JoinedAt != wireTime(directGrant.GrantedAt) {
+		t.Errorf("direct member = %+v, want role=write joinedAt=%s", d, wireTime(directGrant.GrantedAt))
 	}
-	if b := byUser[boss.ID]; b.Account != "boss@x.com" || b.Role != "read" || b.JoinedAt != nil {
-		t.Errorf("inherited member = %+v, want account=boss@x.com role=read joinedAt=null", b)
+	if b := byUser[boss.ID]; b.Account != "boss@x.com" || b.Role != "read" || b.JoinedAt != wireTime(bossGrant.GrantedAt) {
+		t.Errorf("inherited member = %+v, want account=boss@x.com role=read joinedAt=%s", b, wireTime(bossGrant.GrantedAt))
+	}
+
+	// The header/tree counts use the same effective-member meaning as list total.
+	_, detailBody := f.do(t, http.MethodGet, "/teams/"+teamA.ID, "")
+	var detail struct {
+		MemberCount int `json:"memberCount"`
+	}
+	if err := json.Unmarshal(detailBody, &detail); err != nil || detail.MemberCount != total {
+		t.Fatalf("team detail memberCount=%d, list total=%d (err=%v, body=%s)", detail.MemberCount, total, err, detailBody)
+	}
+	_, treeBody := f.do(t, http.MethodGet, "/teams/tree", "")
+	var tree []struct {
+		ID          string `json:"id"`
+		MemberCount int    `json:"memberCount"`
+	}
+	if err := json.Unmarshal(treeBody, &tree); err != nil {
+		t.Fatalf("unmarshal tree: %v (body=%s)", err, treeBody)
+	}
+	var treeCount int
+	for _, node := range tree {
+		if node.ID == teamA.ID {
+			treeCount = node.MemberCount
+			break
+		}
+	}
+	if treeCount != total {
+		t.Fatalf("tree memberCount=%d, list total=%d", treeCount, total)
 	}
 
 	// Promote the inherited boss to write on TeamA via the team role batch — a
@@ -1341,8 +1374,15 @@ func TestConsoleTeamMembersIncludeInherited(t *testing.T) {
 	if total != 2 {
 		t.Fatalf("post-promotion total=%d, want 2 (%+v)", total, byUser)
 	}
-	if b := byUser[boss.ID]; b.Role != "write" || b.JoinedAt == nil {
-		t.Errorf("after promotion boss = %+v, want role=write with a non-null joinedAt", b)
+	var promoted groups.Membership
+	for _, m := range gs.ListMemberships() {
+		if m.User == boss.ID && m.GroupID == teamA.ID {
+			promoted = m
+			break
+		}
+	}
+	if b := byUser[boss.ID]; b.Role != "write" || b.JoinedAt != wireTime(promoted.GrantedAt) {
+		t.Errorf("after promotion boss = %+v, want role=write joinedAt=%s", b, wireTime(promoted.GrantedAt))
 	}
 }
 

--- a/internal/server/console_api_users.go
+++ b/internal/server/console_api_users.go
@@ -330,6 +330,17 @@ func (idx *userIndex) userDTO(m members.Member) userDTO {
 
 // memberDTO builds the team-member-table row for a membership.
 func (idx *userIndex) memberDTO(m groups.Membership) memberDTO {
+	return idx.consoleTeamMemberDTO(groups.ConsoleTeamMember{
+		User:          m.User,
+		Role:          m.Role,
+		SourceGroupID: m.GroupID,
+		GrantedAt:     m.GrantedAt,
+	})
+}
+
+// consoleTeamMemberDTO attaches member identity/status fields to the groups
+// store's consistent direct-or-inherited team-member projection.
+func (idx *userIndex) consoleTeamMemberDTO(m groups.ConsoleTeamMember) memberDTO {
 	account, username := "", ""
 	st := memberStatuses{invitation: "invite_pending", session: "offline"}
 	if mem, ok := idx.memberByID[m.User]; ok {
@@ -342,31 +353,9 @@ func (idx *userIndex) memberDTO(m groups.Membership) memberDTO {
 		Role:             string(m.Role),
 		InvitationStatus: st.invitation,
 		SessionStatus:    st.session,
-		// joinedAt == the membership's granted_at, truncated to the wire's
-		// second precision (storage is canonical millisecond RFC3339). A direct
-		// grant always carries a granted_at, so this is never null here.
-		JoinedAt: wireTimePtr(m.GrantedAt),
-	}
-}
-
-// inheritedMemberDTO builds a team-member row for a user who reaches the team
-// only by downward inheritance (no stored membership row): the role is always
-// read and joinedAt is null, since there is no grant to timestamp. Shown in the
-// team member table alongside direct members without distinction.
-func (idx *userIndex) inheritedMemberDTO(userID string) memberDTO {
-	account, username := "", ""
-	st := memberStatuses{invitation: "invite_pending", session: "offline"}
-	if mem, ok := idx.memberByID[userID]; ok {
-		account, username, st = mem.Email, mem.DisplayName, idx.statuses(mem)
-	}
-	return memberDTO{
-		UserID:           userID,
-		Account:          account,
-		Username:         username,
-		Role:             string(groups.RoleRead),
-		InvitationStatus: st.invitation,
-		SessionStatus:    st.session,
-		JoinedAt:         nil,
+		// GrantedAt is the target membership timestamp for a direct row or the
+		// nearest source membership timestamp for an inherited row.
+		JoinedAt: wireTime(m.GrantedAt),
 	}
 }
 


### PR DESCRIPTION
- 팀의 멤버 수 기준을 멤버십 명시적 소속 뿐만 아니라 실제 목록에 노출되는 유효 멤버*로 변경
  *직접 멤버와 상위 그룹에서 재귀적으로 read를 상속받은 멤버를 포함
- 상속 멤버의 합류일은 가장 가까운 상위 소속 그룹의 합류일로 표시