### PR TITLE
fix(install): use per-OS root group for backup dir on macOS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -105,8 +105,8 @@ done
 
 # ── Platform detection ─────────────────────────────────────────────────────────
 case "$(uname -s)" in
-  Linux)  OS_SLUG=linux ;;
-  Darwin) OS_SLUG=darwin ;;
+  Linux)  OS_SLUG=linux;  ROOT_GROUP=root ;;
+  Darwin) OS_SLUG=darwin; ROOT_GROUP=wheel ;;
   *)      die "Unsupported OS: $(uname -s). Only Linux and macOS are supported." ;;
 esac
 case "$(uname -m)" in
@@ -1097,7 +1097,7 @@ setup_system() {
     # the consumer can verify that its gid matches the trusted parent.
     install -d -m 2770 -o root -g "$SERVICE_USER" "$UPDATE_INBOX_DIR"
     install -d -m 2770 -o root -g "$SERVICE_USER" "$UPDATE_STAGING_DIR"
-    install -d -m 0700 -o root -g root "$UPDATE_BACKUP_DIR"
+    install -d -m 0700 -o root -g "$ROOT_GROUP" "$UPDATE_BACKUP_DIR"
   fi
 
   # /opt may not exist on fresh macOS


### PR DESCRIPTION
## 문제

macOS에서 `curl -fsSL https://rune.team/install.sh | sudo bash` 실행 시 다음 에러로 설치가 중단됨:

```
install: unknown group root
```

원인: 웹 업데이터 백업 디렉터리(`/var/backups/runeconsole`)를 `install -d ... -g root`로 생성하는데, macOS에서는 root의 primary 그룹이 `root`가 아니라 `wheel`이라 해당 그룹이 존재하지 않음. `setup_system`의 다른 `install -d` 줄들은 `-g "$SERVICE_USER"`를 쓰기 때문에 이 백업 디렉터리 한 줄만 실패했음.

## 수정

플랫폼 감지 블록에 OS별 `ROOT_GROUP`(Linux=`root`, macOS=`wheel`)을 `OS_SLUG` 옆에 추가하고, 백업 디렉터리 생성에서 이를 사용.

백업 디렉터리는 여전히 root 소유 + mode `0700`이라, 비특권 `runeconsole` 데몬이 롤백 백업을 건드릴 수 없는 격리(fail-closed)가 그대로 유지됨. 플랫폼에 맞게 그룹 *이름*만 교정한 것.

`inbox`/`staging`이 의도적으로 `$SERVICE_USER` 그룹(2770, 그룹 쓰기 통로)인 것과 달리, 백업 디렉터리는 root 전용이어야 하므로 `$SERVICE_USER`가 아닌 root 그룹을 유지함.

## 반영 경로

`rune.team/install.sh`는 runespace-cloud 프론트가 `raw.githubusercontent.com/CryptoLabInc/rune-console/main/install.sh`로 proxy하는 구조(moving ref). 따라서 이 PR이 `main`에 머지되면 별도 릴리스/재배포 없이 GitHub raw 캐시(~5분) 이내에 사용자에게 반영됨.

## 검증

- `bash -n install.sh` 통과
- diff는 의도한 두 줄만 변경