### PR TITLE
fix(install): use per-OS root group for backup dir on macOS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -105,8 +105,8 @@ done
 
 # ── Platform detection ─────────────────────────────────────────────────────────
 case "$(uname -s)" in
-  Linux)  OS_SLUG=linux ;;
-  Darwin) OS_SLUG=darwin ;;
+  Linux)  OS_SLUG=linux;  ROOT_GROUP=root ;;
+  Darwin) OS_SLUG=darwin; ROOT_GROUP=wheel ;;
   *)      die "Unsupported OS: $(uname -s). Only Linux and macOS are supported." ;;
 esac
 case "$(uname -m)" in
@@ -1097,7 +1097,7 @@ setup_system() {
     # the consumer can verify that its gid matches the trusted parent.
     install -d -m 2770 -o root -g "$SERVICE_USER" "$UPDATE_INBOX_DIR"
     install -d -m 2770 -o root -g "$SERVICE_USER" "$UPDATE_STAGING_DIR"
-    install -d -m 0700 -o root -g root "$UPDATE_BACKUP_DIR"
+    install -d -m 0700 -o root -g "$ROOT_GROUP" "$UPDATE_BACKUP_DIR"
   fi
 
   # /opt may not exist on fresh macOS


### PR DESCRIPTION
## Problem

On macOS, `curl -fsSL https://rune.team/install.sh | sudo bash` aborts with:

```
install: unknown group root
```

Cause: the web-updater backup directory (`/var/backups/runeconsole`) is created with `install -d ... -g root`, but on macOS root's primary group is `wheel`, not `root`, so that group does not exist. The other `install -d` lines in `setup_system` use `-g "$SERVICE_USER"`, so only this backup-dir line failed.

## Fix

Add a per-OS `ROOT_GROUP` (Linux=`root`, macOS=`wheel`) alongside `OS_SLUG` in the platform-detection block, and use it when creating the backup dir.

The backup dir stays root-owned and mode `0700`, so the unprivileged `runeconsole` daemon still cannot touch rollback backups (fail-closed). Only the group *name* is corrected for the platform.

Unlike `inbox`/`staging`, which are intentionally in the `$SERVICE_USER` group (2770, the group-writable channel), the backup dir must be root-only, so it keeps the root group rather than `$SERVICE_USER`.

## Delivery path

`rune.team/install.sh` is served by the runespace-cloud frontend proxying `raw.githubusercontent.com/CryptoLabInc/rune-console/main/install.sh` (a moving ref). So once this PR merges into `main`, the fix reaches users within GitHub raw's cache window (~5 min) — no release or redeploy needed. This is a script hotfix rather than a versioned release, hence the `hotfix/*` branch instead of `release/*`.

## Verification

- `bash -n install.sh` passes
- Diff touches only the two intended lines