### PR TITLE
fix(console): soft-block non-owner login and expire withdrawn sessions

### DIFF
--- a/frontend/src/components/auth/OwnerLockedNotice.tsx
+++ b/frontend/src/components/auth/OwnerLockedNotice.tsx
@@ -1,0 +1,63 @@
+import { useNavigate } from "react-router";
+import { useQueryClient } from "@tanstack/react-query";
+
+import Button from "@/components/elements/Button";
+import RuneMark from "@/components/elements/RuneMark";
+import PublicNavbar from "@/components/navigation/PublicNavbar";
+import { postLogout } from "@/api/authAPIs";
+import { BTN_TEXT, PATH_LIST, QUERY_KEYS } from "@/constants/commonConstants";
+
+/**
+ * OwnerLockedNotice is the soft-block screen shown when a signed-in account is
+ * NOT the console owner (GET /console/session → is_owner:false). The console is
+ * a single-admin surface: the first account to sign in claims it, and any other
+ * account is let in only far enough to learn who owns it and switch — never into
+ * the admin shell. Sign out returns to the login screen so a different Google
+ * account can be chosen.
+ */
+const OwnerLockedNotice = ({ owner }: { owner?: string }) => {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const handleSignOut = async () => {
+    try {
+      await postLogout(); // idempotent server-side
+    } finally {
+      queryClient.setQueryData([QUERY_KEYS.session], { logged_in: false });
+      navigate(PATH_LIST.login);
+    }
+  };
+
+  return (
+    <div className="bg-background flex min-h-screen flex-col">
+      <PublicNavbar />
+      <main className="grid flex-1 place-items-center px-4">
+        <div className="border-border bg-panel-solid flex w-100 flex-col gap-8 rounded-lg border p-7 text-center">
+          <div className="flex items-center justify-center gap-2">
+            <RuneMark />
+            <h1 className="text-lg font-semibold">사용할 수 없는 계정</h1>
+          </div>
+          <p className="text-muted-foreground text-md">
+            이 콘솔은{" "}
+            {owner ? (
+              <span className="text-foreground font-medium">{owner}</span>
+            ) : (
+              "다른 계정"
+            )}
+            이(가) 관리하고 있어요.
+            <br />
+            이 계정으로는 콘솔을 사용할 수 없습니다.
+          </p>
+          <Button
+            btnText={BTN_TEXT.signOut}
+            btnSize="lg"
+            btnColor="mintFilled"
+            handleClick={handleSignOut}
+          />
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default OwnerLockedNotice;

--- a/frontend/src/components/auth/RequireAuth.tsx
+++ b/frontend/src/components/auth/RequireAuth.tsx
@@ -1,5 +1,6 @@
 import { Navigate, Outlet } from "react-router";
 
+import OwnerLockedNotice from "@/components/auth/OwnerLockedNotice";
 import { useSessionQuery } from "@/hooks/queries/useSessionQuery";
 import { PATH_LIST } from "@/constants/commonConstants";
 
@@ -8,11 +9,18 @@ import { PATH_LIST } from "@/constants/commonConstants";
  * unreachable while logged out, so an absent session redirects to the sign-in
  * screen. While the session is still resolving it renders nothing (a shared
  * loading state can slot in here later).
+ *
+ * Single-admin soft block: a signed-in account that is not the console owner
+ * (is_owner === false) reaches the app but cannot use it — show the owner-locked
+ * notice instead of the shell. is_owner is only ever explicitly false here; an
+ * older backend that omits it (undefined) is treated as the owner (no gate).
  */
 const RequireAuth = () => {
   const { data, isPending } = useSessionQuery();
   if (isPending) return null;
   if (!data?.logged_in) return <Navigate to={PATH_LIST.login} replace />;
+  if (data.is_owner === false)
+    return <OwnerLockedNotice owner={data.owner_email} />;
   return <Outlet />;
 };
 

--- a/frontend/src/components/auth/__tests__/RequireAuth.test.tsx
+++ b/frontend/src/components/auth/__tests__/RequireAuth.test.tsx
@@ -45,6 +45,22 @@ describe("RequireAuth", () => {
     expect(await screen.findByText("TEAMS CONTENT")).toBeInTheDocument();
   });
 
+  it("shows the owner-locked notice for a non-owner (soft block)", async () => {
+    vi.spyOn(authAPIs, "getConsoleSession").mockResolvedValue(
+      jsonRes({
+        logged_in: true,
+        expires_at: "2026-07-16T21:00:00Z",
+        me: { email: "bob@corp.com" },
+        is_owner: false,
+        owner_email: "alice@corp.com",
+      }),
+    );
+    renderGuard();
+    expect(await screen.findByText("사용할 수 없는 계정")).toBeInTheDocument();
+    expect(screen.getByText("alice@corp.com")).toBeInTheDocument();
+    expect(screen.queryByText("TEAMS CONTENT")).not.toBeInTheDocument();
+  });
+
   it("redirects to /login when logged out", async () => {
     vi.spyOn(authAPIs, "getConsoleSession").mockResolvedValue(
       jsonRes({ logged_in: false }),

--- a/frontend/src/types/authTypes.ts
+++ b/frontend/src/types/authTypes.ts
@@ -15,7 +15,19 @@ export type TSessionMe = {
 /**
  * TSession is the /console/session response — the single truth for the route
  * guard. It always resolves 200; the discriminant is `logged_in`.
+ *
+ * The console is a single-admin surface: the first account to sign in claims it
+ * as the owner. `is_owner` is false when a DIFFERENT account is signed in (soft
+ * block) — it reaches the app but cannot use it, and `owner_email` names the
+ * owner so the UI can say whom to ask. Both are optional for forward-compat with
+ * an older backend that omits them (treated as owner — no gate).
  */
 export type TSession =
   | { logged_in: false }
-  | { logged_in: true; expires_at: string; me: TSessionMe };
+  | {
+      logged_in: true;
+      expires_at: string;
+      me: TSessionMe;
+      is_owner?: boolean;
+      owner_email?: string;
+    };

--- a/internal/console/console_test.go
+++ b/internal/console/console_test.go
@@ -169,11 +169,20 @@ func TestSessionEndpointNoCookie(t *testing.T) {
 }
 
 func TestSessionEndpointLoggedInIncludesPlan(t *testing.T) {
+	// The session check revalidates a live session against the cloud, so point at
+	// a mock whose /me returns 200 (the cloud session still exists).
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v1/me", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{"email": "a@x.io"})
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
 	db := openTestDB(t)
 	h, _, err := NewHandler(Deps{
 		Port:       8787,
-		APIBaseURL: "http://cloud.invalid",
-		WebBaseURL: "http://web.invalid",
+		APIBaseURL: ts.URL,
+		WebBaseURL: ts.URL,
 		DB:         db,
 	})
 	if err != nil {

--- a/internal/console/login.go
+++ b/internal/console/login.go
@@ -113,9 +113,14 @@ func (s *Service) handleCallback(w http.ResponseWriter, r *http.Request) {
 		me = raw
 	}
 
-	// Single-admin binding: the FIRST account to log in claims this console; a
-	// later login by a different account is refused (BFF spec: the console is a
-	// single-admin surface). The principal email is the stable ownership key.
+	// Single-admin ownership: the FIRST account to log in claims this console as
+	// its owner (the org admin). A later login by a DIFFERENT account is a SOFT
+	// block — it still receives a console session and reaches the app, but it is
+	// not granted org-admin authority and the app surfaces an owner-locked notice
+	// (GET /console/session → is_owner:false). This replaced a hard refusal that
+	// dead-ended the browser on the login screen: a non-owner (e.g. after the
+	// owner withdrew their cloud account) could not even learn who owns the
+	// console or switch accounts. The principal email is the stable ownership key.
 	email := emailFromMe(me)
 	if email == "" {
 		// No principal email means ownership cannot be established or verified —
@@ -131,24 +136,24 @@ func (s *Service) handleCallback(w http.ResponseWriter, r *http.Request) {
 		s.failCallback(w, r, "exchange_failed")
 		return
 	}
-	if !strings.EqualFold(own.Email, email) {
-		// A different account already owns this console. Best-effort revoke the
-		// cloud session we just minted (this login gets no console session) and
-		// bounce to the locked-out login screen naming the owning account.
-		_ = s.cloud.RevokeSession(r.Context(), tok.CookieName+"="+tok.SessionToken)
-		s.log.Warn("console: login refused — console is bound to another admin", "owner", own.Email, "attempted", email)
-		s.failOwnerLocked(w, r, own.Email)
-		return
+	if strings.EqualFold(own.Email, email) {
+		// The owner (first-login claim, or any subsequent owner login): derive the
+		// single org admin from the console owner (grant authority via SetOrgAdmin).
+		// The admin is a management-plane identity and is NOT seeded a member
+		// registry row — an admin who wants to appear in member listings invites an
+		// email through the normal flow, which creates a real row. Idempotent,
+		// creates zero group memberships (admin reach is granted, never implied),
+		// and never blocks login (see the helper).
+		s.registerOwnerBestEffort(email, me, "login")
+	} else {
+		// A different account owns this console. Grant the session (soft block) but
+		// withhold org-admin authority: the registrar never runs for a non-owner,
+		// so this account cannot take over the incumbent's admin reach. The app
+		// reads is_owner:false from /console/session and shows the owner-locked
+		// notice instead of the admin surfaces.
+		s.log.Warn("console: non-owner login — session granted, org-admin withheld",
+			"owner", own.Email, "account", email)
 	}
-
-	// First-login registration: derive the single org admin from the console
-	// owner (grant authority via SetOrgAdmin). The admin is a management-plane
-	// identity and is NOT seeded a member registry row — an admin who wants to
-	// appear in member listings and/or be granted memberships invites an email
-	// (their own or another) through the normal flow, which creates a real row.
-	// Idempotent, creates zero group memberships (admin reach is granted, never
-	// implied), and never blocks login (see the helper).
-	s.registerOwnerBestEffort(email, me, "login")
 
 	sess, err := s.sessions.create(tok.SessionToken, tok.CookieName, me)
 	if err != nil {
@@ -186,17 +191,6 @@ func (s *Service) handleLogout(w http.ResponseWriter, r *http.Request) {
 func (s *Service) failCallback(w http.ResponseWriter, r *http.Request, code string) {
 	http.SetCookie(w, &http.Cookie{Name: cookieName, Value: "", Path: "/", HttpOnly: true, MaxAge: -1})
 	http.Redirect(w, r, s.selfBase+"/login?error="+url.QueryEscape(code), http.StatusFound)
-}
-
-// failOwnerLocked clears any cookie and bounces to the login page with the
-// admin_locked code plus the owning account, so the SPA can tell the user which
-// account manages this console (and whom to contact). Naming the owner is a
-// deliberate choice: the console is a loopback-only surface, the owner email is
-// not otherwise sensitive here, and the message is useless without it.
-func (s *Service) failOwnerLocked(w http.ResponseWriter, r *http.Request, ownerAccount string) {
-	http.SetCookie(w, &http.Cookie{Name: cookieName, Value: "", Path: "/", HttpOnly: true, MaxAge: -1})
-	loc := s.selfBase + "/login?error=admin_locked&owner=" + url.QueryEscape(ownerAccount)
-	http.Redirect(w, r, loc, http.StatusFound)
 }
 
 func randToken(nbytes int) (string, error) {

--- a/internal/console/owner_test.go
+++ b/internal/console/owner_test.go
@@ -196,15 +196,36 @@ func doLogin(t *testing.T, h http.Handler, code string) *httptest.ResponseRecord
 }
 
 func hasSessionCookie(rr *httptest.ResponseRecorder) bool {
-	for _, c := range rr.Result().Cookies() {
-		if c.Name == cookieName && c.Value != "" {
-			return true
-		}
-	}
-	return false
+	return sessionCookieValue(rr) != ""
 }
 
-func TestCallbackBindsFirstAdminAndBlocksOthers(t *testing.T) {
+// sessionCookieValue returns the value of the session cookie the response set,
+// or "" when none was set (or it was cleared).
+func sessionCookieValue(rr *httptest.ResponseRecorder) string {
+	for _, c := range rr.Result().Cookies() {
+		if c.Name == cookieName {
+			return c.Value
+		}
+	}
+	return ""
+}
+
+// getSession drives GET /console/session with the given session cookie and
+// returns the decoded body.
+func getSession(t *testing.T, h http.Handler, cookieVal string) map[string]any {
+	t.Helper()
+	req := httptest.NewRequest("GET", "/console/session", nil) // same-origin
+	req.AddCookie(&http.Cookie{Name: cookieName, Value: cookieVal})
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	var body map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("session body: %v (%s)", err, rr.Body.String())
+	}
+	return body
+}
+
+func TestCallbackBindsFirstAdminAndSoftGatesOthers(t *testing.T) {
 	ts := mockLoginCloud(t, map[string]string{
 		"tokA":  "alice@x.io",
 		"tokA2": "alice@x.io",
@@ -220,7 +241,8 @@ func TestCallbackBindsFirstAdminAndBlocksOthers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// First login (alice) claims the console: 302 to "/" with a session cookie.
+	// First login (alice) claims the console: 302 to "/" with a session cookie,
+	// and the session reports her as the owner.
 	rr := doLogin(t, h, "tokA")
 	if rr.Code != http.StatusFound {
 		t.Fatalf("first login status = %d, want 302", rr.Code)
@@ -229,33 +251,94 @@ func TestCallbackBindsFirstAdminAndBlocksOthers(t *testing.T) {
 		t.Errorf("first login → %q, want redirect to /", loc)
 	}
 	if !hasSessionCookie(rr) {
-		t.Error("first login set no session cookie")
+		t.Fatal("first login set no session cookie")
+	}
+	if s := getSession(t, h, sessionCookieValue(rr)); s["is_owner"] != true {
+		t.Errorf("owner session is_owner = %v, want true", s["is_owner"])
 	}
 
-	// A different account (bob) is refused: 302 to the admin_locked screen naming
-	// the owner, and no session cookie.
+	// A different account (bob) is SOFT-blocked: it still gets a console session
+	// (302 to "/", cookie set, no error code), but /console/session reports
+	// is_owner:false and names the owner so the app can show the owner-locked
+	// notice instead of the admin shell.
 	rr = doLogin(t, h, "tokB")
 	if rr.Code != http.StatusFound {
-		t.Fatalf("blocked login status = %d, want 302", rr.Code)
+		t.Fatalf("non-owner login status = %d, want 302", rr.Code)
 	}
-	loc := rr.Header().Get("Location")
-	if !strings.Contains(loc, "/login?error=admin_locked") {
-		t.Errorf("blocked login → %q, want error=admin_locked", loc)
+	if loc := rr.Header().Get("Location"); strings.Contains(loc, "error=") {
+		t.Errorf("non-owner login → %q, want no error (soft block)", loc)
 	}
-	if !strings.Contains(loc, "owner="+url.QueryEscape("alice@x.io")) {
-		t.Errorf("blocked login → %q, want owner=alice@x.io", loc)
+	bobCookie := sessionCookieValue(rr)
+	if bobCookie == "" {
+		t.Fatal("non-owner login set no session cookie (soft block must grant one)")
 	}
-	if hasSessionCookie(rr) {
-		t.Error("blocked login must not set a session cookie")
+	bobSess := getSession(t, h, bobCookie)
+	if bobSess["logged_in"] != true {
+		t.Errorf("non-owner session logged_in = %v, want true", bobSess["logged_in"])
+	}
+	if bobSess["is_owner"] != false {
+		t.Errorf("non-owner session is_owner = %v, want false", bobSess["is_owner"])
+	}
+	if bobSess["owner_email"] != "alice@x.io" {
+		t.Errorf("non-owner session owner_email = %v, want alice@x.io", bobSess["owner_email"])
 	}
 
-	// The owner logging in again (fresh cloud session) still succeeds.
+	// The owner logging in again (fresh cloud session) still succeeds and stays
+	// the owner.
 	rr = doLogin(t, h, "tokA2")
 	if rr.Code != http.StatusFound || !hasSessionCookie(rr) {
 		t.Errorf("owner re-login status=%d cookie=%v, want 302 + cookie", rr.Code, hasSessionCookie(rr))
 	}
 	if loc := rr.Header().Get("Location"); strings.Contains(loc, "error=") {
 		t.Errorf("owner re-login → %q, want no error", loc)
+	}
+	if s := getSession(t, h, sessionCookieValue(rr)); s["is_owner"] != true {
+		t.Errorf("owner re-login session is_owner = %v, want true", s["is_owner"])
+	}
+}
+
+func TestSessionExpiresWhenCloudAccountWithdrawn(t *testing.T) {
+	// After the owner withdraws their cloud account, the cloud cascade-deletes
+	// its sessions, so GET /me with the stored token returns 401. The console
+	// session check must detect that and expire the local login on the spot,
+	// rather than keep reporting logged-in off the local snapshot.
+	var withdrawn bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /auth/local/token", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		writeJSON(w, http.StatusOK, map[string]string{"session_token": r.FormValue("code"), "cookie_name": "rc_cloud"})
+	})
+	mux.HandleFunc("GET /api/v1/me", func(w http.ResponseWriter, _ *http.Request) {
+		if withdrawn {
+			writeError(w, http.StatusUnauthorized, "UNAUTHORIZED", "no session")
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"email": "alice@x.io"})
+	})
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	h, _, err := NewHandler(Deps{Port: 8787, APIBaseURL: ts.URL, WebBaseURL: ts.URL, DB: openTestDB(t)})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := doLogin(t, h, "tokA")
+	if rr.Code != http.StatusFound || !hasSessionCookie(rr) {
+		t.Fatalf("login status=%d cookie=%v, want 302 + cookie", rr.Code, hasSessionCookie(rr))
+	}
+	cookie := sessionCookieValue(rr)
+
+	// While the account exists the session check reports logged-in.
+	if s := getSession(t, h, cookie); s["logged_in"] != true {
+		t.Fatalf("pre-withdrawal logged_in = %v, want true", s["logged_in"])
+	}
+
+	// After withdrawal the cloud rejects the stored token (401) → the session
+	// check expires the local login.
+	withdrawn = true
+	if s := getSession(t, h, cookie); s["logged_in"] != false {
+		t.Errorf("post-withdrawal logged_in = %v, want false", s["logged_in"])
 	}
 }
 
@@ -342,12 +425,12 @@ func TestOwnerRegistrarRunsOnClaimingLoginOnly(t *testing.T) {
 		t.Fatalf("registrar after first login = %v, want [alice@x.io]", emails)
 	}
 
-	// A refused login (different account) must NOT reach the registrar: the
-	// incumbent keeps admin authority.
-	if rr := doLogin(t, h, "tokB"); !strings.Contains(rr.Header().Get("Location"), "admin_locked") {
-		t.Fatalf("bob's login was not refused")
+	// A non-owner login is soft-blocked: it succeeds (302 + session cookie) but
+	// must NOT reach the registrar — the incumbent keeps admin authority.
+	if rr := doLogin(t, h, "tokB"); rr.Code != http.StatusFound || !hasSessionCookie(rr) {
+		t.Fatalf("non-owner login status=%d cookie=%v, want 302 + cookie", rr.Code, hasSessionCookie(rr))
 	}
 	if len(emails) != 1 {
-		t.Errorf("registrar ran for a refused login: %v", emails)
+		t.Errorf("registrar ran for a non-owner login: %v", emails)
 	}
 }

--- a/internal/console/service.go
+++ b/internal/console/service.go
@@ -236,28 +236,66 @@ func (s *Service) registerOwnerBestEffort(email string, me json.RawMessage, at s
 }
 
 // handleSession (GET /console/session) is the route guard's single source of
-// truth, so it always returns 200 — never 401.
+// truth, so it always returns 200 — never 401. A live local session is
+// revalidated against the cloud before it is reported as logged-in: an account
+// whose cloud session no longer exists — most importantly a WITHDRAWN account,
+// whose cloud sessions are cascade-deleted — must not keep reporting logged-in
+// off the local snapshot, so such a session is expired here on the spot.
 func (s *Service) handleSession(w http.ResponseWriter, r *http.Request) {
-	if c, err := r.Cookie(cookieName); err == nil {
-		if sess := s.sessions.get(c.Value); sess != nil {
-			resp := map[string]any{
-				"logged_in":        true,
-				"expires_at":       sess.ExpiresAt.UTC().Format(time.RFC3339),
-				"engine_connected": s.engineReady(),
-				// TODO(plan-source): the account's subscription plan. The cloud
-				// source is undecided (workspace tier vs principal vs billing
-				// API), so this is a placeholder. Replace this one line with the
-				// real lookup once the source is settled; the wire contract
-				// (lowercase string, open value set) stays the same.
-				"plan": "free",
-			}
-			if len(sess.Me) > 0 {
-				resp["me"] = meWithAvatar(sess.Me)
-			}
-			writeJSON(w, http.StatusOK, resp)
-			return
+	c, err := r.Cookie(cookieName)
+	if err != nil {
+		s.writeLoggedOut(w)
+		return
+	}
+	sess := s.sessions.get(c.Value)
+	if sess == nil {
+		s.writeLoggedOut(w)
+		return
+	}
+
+	// Revalidate against the cloud. Me() returns a nil principal with a nil error
+	// ONLY on a 401 — the "this cloud session no longer exists" signal, which a
+	// withdrawn account produces. Any other error is transient (network / 5xx):
+	// keep the local session rather than log the owner out over a blip.
+	if raw, merr := s.cloud.Me(r.Context(), sess.CloudCookie()); merr == nil && raw == nil {
+		s.log.Info("console: cloud session gone (account withdrawn or revoked) — expiring console login")
+		s.sessions.delete(sess.ID)
+		http.SetCookie(w, &http.Cookie{Name: cookieName, Value: "", Path: "/", HttpOnly: true, MaxAge: -1})
+		s.writeLoggedOut(w)
+		return
+	}
+
+	resp := map[string]any{
+		"logged_in":        true,
+		"expires_at":       sess.ExpiresAt.UTC().Format(time.RFC3339),
+		"engine_connected": s.engineReady(),
+		// TODO(plan-source): the account's subscription plan. The cloud source is
+		// undecided (workspace tier vs principal vs billing API), so this is a
+		// placeholder. Replace this one line with the real lookup once the source
+		// is settled; the wire contract (lowercase string, open value set) stays.
+		"plan": "free",
+	}
+	if len(sess.Me) > 0 {
+		resp["me"] = meWithAvatar(sess.Me)
+	}
+	// Owner status (single-admin surface). The owner is the account that first
+	// claimed the console; any other logged-in account is a soft block — the app
+	// shows an owner-locked notice instead of the admin surfaces. Naming the owner
+	// lets that notice say whom to ask. A read failure fails OPEN (is_owner:true):
+	// the alternative would lock the real owner out over a transient DB error.
+	isOwner := true
+	if o, oerr := s.owner.get(); oerr == nil && o != nil {
+		isOwner = strings.EqualFold(o.Email, emailFromMe(sess.Me))
+		if !isOwner {
+			resp["owner_email"] = o.Email
 		}
 	}
+	resp["is_owner"] = isOwner
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// writeLoggedOut emits the single logged-out session body (always 200).
+func (s *Service) writeLoggedOut(w http.ResponseWriter) {
 	writeJSON(w, http.StatusOK, map[string]any{"logged_in": false, "engine_connected": s.engineReady()})
 }
 


### PR DESCRIPTION
## Problem

The single-admin lock hard-refused a non-owner at the OAuth callback (`admin_locked`), so once the owner (A) withdrew their cloud account the console was bricked — a new account (B) couldn't even see who owned it or switch. The local session was also validated only by its 12h TTL, so a withdrawn owner kept reporting logged-in from the cached snapshot.

## Changes

- **`login.go`**: a non-owner login now succeeds (soft block) and gets a session, but the org-admin registrar (`SetOrgAdmin`) runs only for the owner, so a non-owner never takes over admin authority. Removed `failOwnerLocked` / the `admin_locked` bounce.
- **`service.go`**: `GET /console/session` revalidates a live session against the cloud (`/me`). A 401 (nil principal + nil error — the signal a withdrawn account produces) expires the local login on the spot. Response now carries `is_owner` (+ `owner_email` when not owner).
- **frontend**: `RequireAuth` shows `OwnerLockedNotice` for `is_owner:false` instead of the admin shell; `TSession` carries `is_owner`/`owner_email`.

## Out of scope (follow-up)

- **Owner rotation**: the soft block keeps `console_owner` bound to A, so B still hits an "owner-locked" gate — actually taking over the console needs a separate reset/reclaim path.
- **Pending-register**: the console intentionally suppresses continue-signup while a `local_tx` is pending (by design), so it's untouched here.

## Verification

go build / vet / test pass (admin_locked test replaced by soft-gate + withdrawn-session-expiry tests); frontend tsc / eslint clean / vitest 316 pass.