### PR TITLE
fix(frontend): require Node >=22.22.0 to match react-router@8 engine …

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "packageManager": "pnpm@10.34.4",
   "engines": {
-    "node": ">=20"
+    "node": ">=22.22.0"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
react-router@8.2.0 requires Node >=22.22.0, so npm install fails on Node 20 despite our engines field claiming >=20 works. This bumps engines.node to >=22.22.0 to match; verified on Node 22.23.1